### PR TITLE
게임 방 수정 기능 추가

### DIFF
--- a/game-api/src/main/java/com/tang/game/common/type/ErrorCode.java
+++ b/game-api/src/main/java/com/tang/game/common/type/ErrorCode.java
@@ -12,6 +12,8 @@ public enum ErrorCode {
   USER_NOT_FOUND("사용자가 없습니다."),
 
   // Room
+  USER_ROOM_HOST_UN_MATCH("게임방 주인이 아닙니다."),
+  NOT_FOUND_ROOM("존재하지 않는 방입니다."),
   EXIST_ROOM_TITLE("중복된 방 제목입니다.");
 
   private final String description;

--- a/game-api/src/main/java/com/tang/game/room/controller/RoomController.java
+++ b/game-api/src/main/java/com/tang/game/room/controller/RoomController.java
@@ -39,16 +39,21 @@ public class RoomController {
   }
 
   @PutMapping("/{roomId}")
-  ResponseEntity<?> updateRoom(
-      @PathVariable Long roomId
+  void updateRoom(
+      @PathVariable Long roomId,
+      @RequestBody @Valid RoomForm form
   ) {
-    return ResponseEntity.ok(roomService.updateRoom());
+    // 임시로 작성
+    Long userId = 1L;
+
+    roomService.updateRoom(userId, roomId, form);
   }
 
   @DeleteMapping("/{roomId}")
   ResponseEntity<?> deleteRoom(
       @PathVariable Long roomId
   ) {
-    return ResponseEntity.ok(roomService.deleteRoom());
+    return null;
+//    return ResponseEntity.ok(roomService.deleteRoom(roomId));
   }
 }

--- a/game-api/src/main/java/com/tang/game/room/domain/Room.java
+++ b/game-api/src/main/java/com/tang/game/room/domain/Room.java
@@ -61,4 +61,12 @@ public class Room extends BaseEntity {
         .status(RoomStatus.VALID)
         .build();
   }
+
+  public void update(RoomForm form) {
+    setTitle(form.getTitle());
+    setPassword(form.getPassword());
+    setGameType(form.getGameType());
+    setTeamType(form.getTeamType());
+    setLimitedNumberPeople(form.getLimitedNumberPeople());
+  }
 }

--- a/game-api/src/main/java/com/tang/game/room/domain/Room.java
+++ b/game-api/src/main/java/com/tang/game/room/domain/Room.java
@@ -33,7 +33,7 @@ public class Room extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  private Long userId;
+  private Long hostUserId;
 
   private String title;
 
@@ -52,7 +52,7 @@ public class Room extends BaseEntity {
 
   public static Room from(RoomForm form) {
     return Room.builder()
-        .userId(form.getUserId())
+        .hostUserId(form.getUserId())
         .title(form.getTitle())
         .password(form.getPassword())
         .limitedNumberPeople(form.getLimitedNumberPeople())

--- a/game-api/src/main/java/com/tang/game/room/dto/RoomForm.java
+++ b/game-api/src/main/java/com/tang/game/room/dto/RoomForm.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
 
 @Getter
 @Setter
@@ -23,7 +24,7 @@ public class RoomForm {
   @NotNull(message = "방 제목을 입력해주세요.")
   private String title;
 
-  @Max(value = 10, message = "방 비밀번호는 최대 10자리 입니다.")
+  @Length(max = 10, message = "방 비밀번호는 최대 10자리 입니다.")
   private String password;
 
   @Min(value = 1, message = "방 인원은 최소 1명 입니다.")

--- a/game-api/src/main/java/com/tang/game/room/repository/RoomRepository.java
+++ b/game-api/src/main/java/com/tang/game/room/repository/RoomRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface RoomRepository extends JpaRepository<Room, Long> {
 
   boolean existsByTitleAndStatus(String title, RoomStatus status);
+
+  boolean existsByTitleAndStatusAndIdNot(String title, RoomStatus status, Long roomId);
 }

--- a/game-api/src/main/java/com/tang/game/room/service/RoomService.java
+++ b/game-api/src/main/java/com/tang/game/room/service/RoomService.java
@@ -6,6 +6,7 @@ import com.tang.game.room.domain.Room;
 import com.tang.game.room.dto.RoomForm;
 import com.tang.game.room.repository.RoomRepository;
 import com.tang.game.common.type.ErrorCode;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -31,11 +32,29 @@ public class RoomService {
     return null;
   }
 
-  public Object updateRoom() {
-    return null;
+  public void updateRoom(Long userId, Long roomId, RoomForm form) {
+    Room room = roomRepository.findById(roomId).orElseThrow(
+        () -> new JamGameException(ErrorCode.NOT_FOUND_ROOM)
+    );
+
+    validateUpdateRoom(room, form, userId);
+
+    room.update(form);
+
+    roomRepository.save(room);
   }
 
   public Object deleteRoom() {
     return null;
+  }
+
+  private void validateUpdateRoom(Room room, RoomForm form, Long userId) {
+    if (!Objects.equals(room.getHostUserId(), userId)) {
+      throw new JamGameException(ErrorCode.USER_ROOM_HOST_UN_MATCH);
+    }
+
+    if (roomRepository.existsByTitleAndStatusAndIdNot(form.getTitle(), RoomStatus.VALID, room.getId())) {
+      throw new JamGameException(ErrorCode.EXIST_ROOM_TITLE);
+    }
   }
 }

--- a/game-api/src/test/java/com/tang/game/room/controller/RoomControllerTest.java
+++ b/game-api/src/test/java/com/tang/game/room/controller/RoomControllerTest.java
@@ -41,7 +41,7 @@ class RoomControllerTest {
   @Test
   @DisplayName("성공 - 게임 방 생성")
   void
-  success_createRoom() throws Exception {
+  successCreateRoom() throws Exception {
     //given
 
     RoomForm form = RoomForm.builder()
@@ -66,7 +66,36 @@ class RoomControllerTest {
                 preprocessResponse(prettyPrint())
             )
         );
-    ;
+  }
+
+  @Test
+  @DisplayName("성공 - 게임 방 수정")
+  void
+  successUpdateRoom() throws Exception {
+    //given
+
+    RoomForm form = RoomForm.builder()
+        .userId(1L)
+        .title("게임방 제목")
+        .password("0123")
+        .limitedNumberPeople(8)
+        .gameType(GAME_ORDER)
+        .teamType(PERSONAL)
+        .build();
+
+    roomService.updateRoom(1L, 1L, form);
+    //when
+    //then
+    mockMvc.perform(post("/rooms/1"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andDo(
+            document(
+                "{class-name}/{method-name}",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint())
+            )
+        );
   }
 
 }

--- a/game-api/src/test/java/com/tang/game/room/service/RoomServiceTest.java
+++ b/game-api/src/test/java/com/tang/game/room/service/RoomServiceTest.java
@@ -4,6 +4,7 @@ import static com.tang.game.common.type.GameType.GAME_ORDER;
 import static com.tang.game.common.type.TeamType.PERSONAL;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
@@ -14,6 +15,7 @@ import com.tang.game.common.type.ErrorCode;
 import com.tang.game.room.domain.Room;
 import com.tang.game.room.dto.RoomForm;
 import com.tang.game.room.repository.RoomRepository;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,7 +43,7 @@ class RoomServiceTest {
     ArgumentCaptor<Room> captor = ArgumentCaptor.forClass(Room.class);
 
     //when
-    roomService.createRoom(getCreateRoomForm());
+    roomService.createRoom(getRoomForm());
 
     //then
     verify(roomRepository, times(1)).save(captor.capture());
@@ -60,21 +62,94 @@ class RoomServiceTest {
     given(roomRepository.existsByTitleAndStatus(anyString(), any()))
         .willReturn(true);
 
+    //when
+    JamGameException exception = assertThrows(JamGameException.class,
+        () -> roomService.createRoom(getRoomForm()));
+
+    //then
+    assertEquals(ErrorCode.EXIST_ROOM_TITLE, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("성공 - 방 수정")
+  void successUpdateRoom() {
+    //given
+    given(roomRepository.findById(anyLong()))
+        .willReturn(Optional.of(getRoom()));
+
+    given(roomRepository.existsByTitleAndStatusAndIdNot(anyString(), any(), anyLong()))
+        .willReturn(false);
+
     ArgumentCaptor<Room> captor = ArgumentCaptor.forClass(Room.class);
 
     //when
+    roomService.updateRoom(1L, 1L, getRoomForm("게임방 제목 변경"));
+
+    //then
+    verify(roomRepository, times(1)).save(captor.capture());
+    assertEquals(captor.getValue().getHostUserId(), 1L);
+    assertEquals(captor.getValue().getTitle(), "게임방 제목 변경");
+    assertEquals(captor.getValue().getPassword(), "0123");
+    assertEquals(captor.getValue().getLimitedNumberPeople(), 8);
+    assertEquals(captor.getValue().getTeamType(), PERSONAL);
+    assertEquals(captor.getValue().getGameType(), GAME_ORDER);
+  }
+
+  @Test
+  @DisplayName("실패 방 수정 - 존재하지 않는 방")
+  void failUpdateRoom_NotFoundRoom() {
+    //given
+    given(roomRepository.findById(anyLong()))
+        .willReturn(Optional.empty());
+
+    //when
     JamGameException exception = assertThrows(JamGameException.class,
-        () -> roomService.createRoom(getCreateRoomForm()));
+        () -> roomService.updateRoom(1L, 1L, getRoomForm()));
+
+    //then
+    assertEquals(ErrorCode.NOT_FOUND_ROOM, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("실패 방 수정 - 게임방 주인이 아님")
+  void failUpdateRoom_HostUnMatch() {
+    //given
+    given(roomRepository.findById(anyLong()))
+        .willReturn(Optional.of(getRoom()));
+
+    //when
+    JamGameException exception = assertThrows(JamGameException.class,
+        () -> roomService.updateRoom(2L, 1L, getRoomForm()));
+
+    //then
+    assertEquals(ErrorCode.USER_ROOM_HOST_UN_MATCH, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("실패 방 수정 - 중복 되는 방제목")
+  void failUpdateRoom_ExistRoomTitle() {
+    //given
+    given(roomRepository.existsByTitleAndStatusAndIdNot(anyString(), any(), anyLong()))
+        .willReturn(true);
+
+    given(roomRepository.findById(anyLong()))
+        .willReturn(Optional.of(getRoom()));
+
+    //when
+    JamGameException exception = assertThrows(JamGameException.class,
+        () -> roomService.updateRoom(1L, 1L, getRoomForm()));
 
     //then
     assertEquals(ErrorCode.EXIST_ROOM_TITLE, exception.getErrorCode());
   }
 
   private Room getRoom() {
-    return Room.from(getCreateRoomForm());
+    Room room = Room.from(getRoomForm());
+    room.setId(1L);
+    return room;
   }
 
-  private RoomForm getCreateRoomForm() {
+  private RoomForm getRoomForm() {
     return RoomForm.builder()
         .userId(1L)
         .title("게임방 제목")
@@ -85,4 +160,14 @@ class RoomServiceTest {
         .build();
   }
 
+  private RoomForm getRoomForm(String title) {
+    return RoomForm.builder()
+        .userId(1L)
+        .title(title)
+        .password("0123")
+        .limitedNumberPeople(8)
+        .gameType(GAME_ORDER)
+        .teamType(PERSONAL)
+        .build();
+  }
 }

--- a/game-api/src/test/java/com/tang/game/room/service/RoomServiceTest.java
+++ b/game-api/src/test/java/com/tang/game/room/service/RoomServiceTest.java
@@ -45,7 +45,7 @@ class RoomServiceTest {
 
     //then
     verify(roomRepository, times(1)).save(captor.capture());
-    assertEquals(captor.getValue().getUserId(), 1L);
+    assertEquals(captor.getValue().getHostUserId(), 1L);
     assertEquals(captor.getValue().getTitle(), "게임방 제목");
     assertEquals(captor.getValue().getPassword(), "0123");
     assertEquals(captor.getValue().getLimitedNumberPeople(), 8);


### PR DESCRIPTION
## 변경사항
### AS-IS
1. 게임 방 수정 기능 추가했습니다.
    - 호스트만 수정이 가능하기 때문에 해당 예외처리를 위해 임의로 userId를 1로 지정 했습니다. 이 부분은 추후에 유저 기능이 추가되면 제거할 예정입니다.
    - 예외처리는 아래 3가지 경우를 예외 처리했습니다.
        - 수정 하는 방 고유 번호가 존재 하는지
        - 수정 하는 사람이 방의 호스트 인지
        - 수정 하는 방의 제목이 중복 되는지(제목이 바뀌지 않은 경우에는 중복 에러 발생하지 않게 처리)
        
2. RoomForm.class의 password의 validation을 잘 못 설정하여 변경
    - Max(10) -> Length(Max = 10)
    
3. Room Entity 컬럼명을 좀 더 확실한 이름으로 변경
    - userId -> hostUserId

### TO-BE
1. 게임 방 삭제

## 테스트
- [x] 테스트 코드
- [x] API 테스트

## 질문
리뷰 요청 봐주셔서 감사합니다! 한가지 질문이 있어서 글을 남깁니다!
1. 현재 Room을 수정하는 경우에  방을 생성했을때와 마찬가지로 title 중복 검사를 합니다. 
2. 하지만 방제목을 수정 하지 않는 경우에 중복 검사를 하게 되면 현재 방 id 를 제외하고 중복검사를 합니다!
3. 제가 올바른 방법으로 수정 기능을 구현한지 잘 모르겠습니다! 혹시 더 좋은 방법이 있다면 말씀해주시면 감사하겠습니다!
