### PR TITLE
게임방  삭제 피드백 적용

### DIFF
--- a/core/src/main/java/com/tang/core/domain/BaseEntity.java
+++ b/core/src/main/java/com/tang/core/domain/BaseEntity.java
@@ -3,7 +3,9 @@ package com.tang.core.domain;
 import java.time.LocalDateTime;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -12,6 +14,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @Setter
 @MappedSuperclass
+@NoArgsConstructor
+@AllArgsConstructor
 @EntityListeners(value = {AuditingEntityListener.class})
 public abstract class BaseEntity {
 
@@ -19,5 +23,4 @@ public abstract class BaseEntity {
   private LocalDateTime createdAt;
   @LastModifiedDate
   private LocalDateTime modifiedAt;
-  private LocalDateTime deletedAt;
 }

--- a/core/src/main/java/com/tang/core/domain/BaseEntity.java
+++ b/core/src/main/java/com/tang/core/domain/BaseEntity.java
@@ -4,11 +4,13 @@ import java.time.LocalDateTime;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
+@Setter
 @MappedSuperclass
 @EntityListeners(value = {AuditingEntityListener.class})
 public abstract class BaseEntity {

--- a/game-api/src/main/java/com/tang/game/room/domain/Room.java
+++ b/game-api/src/main/java/com/tang/game/room/domain/Room.java
@@ -17,6 +17,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.hibernate.annotations.SQLDelete;
 import org.hibernate.envers.AuditOverride;
 
 @Getter
@@ -27,6 +28,7 @@ import org.hibernate.envers.AuditOverride;
 @Entity
 @ToString
 @AuditOverride(forClass = BaseEntity.class)
+@SQLDelete(sql = "UPDATE room SET deleted_at = current_timestamp, status = 'DELETE' WHERE id = ?")
 public class Room extends BaseEntity {
 
   @Id

--- a/game-api/src/main/java/com/tang/game/room/domain/Room.java
+++ b/game-api/src/main/java/com/tang/game/room/domain/Room.java
@@ -5,6 +5,7 @@ import com.tang.game.common.type.GameType;
 import com.tang.game.common.type.RoomStatus;
 import com.tang.game.common.type.TeamType;
 import com.tang.game.room.dto.RoomForm;
+import java.time.LocalDateTime;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -51,6 +52,8 @@ public class Room extends BaseEntity {
 
   @Enumerated(EnumType.STRING)
   private RoomStatus status;
+
+  private LocalDateTime deletedAt;
 
   public static Room from(RoomForm form) {
     return Room.builder()

--- a/game-api/src/main/java/com/tang/game/room/domain/Room.java
+++ b/game-api/src/main/java/com/tang/game/room/domain/Room.java
@@ -29,7 +29,6 @@ import org.hibernate.envers.AuditOverride;
 @Entity
 @ToString
 @AuditOverride(forClass = BaseEntity.class)
-@SQLDelete(sql = "UPDATE room SET deleted_at = current_timestamp, status = 'DELETE' WHERE id = ?")
 public class Room extends BaseEntity {
 
   @Id

--- a/game-api/src/main/java/com/tang/game/room/service/RoomService.java
+++ b/game-api/src/main/java/com/tang/game/room/service/RoomService.java
@@ -1,11 +1,14 @@
 package com.tang.game.room.service;
 
+import static com.tang.game.common.type.RoomStatus.DELETE;
+
 import com.tang.game.common.exception.JamGameException;
-import com.tang.game.common.type.ErrorCode;
 import com.tang.game.common.type.RoomStatus;
 import com.tang.game.room.domain.Room;
 import com.tang.game.room.dto.RoomForm;
 import com.tang.game.room.repository.RoomRepository;
+import com.tang.game.common.type.ErrorCode;
+import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -52,7 +55,9 @@ public class RoomService {
       throw new JamGameException(ErrorCode.USER_ROOM_HOST_UN_MATCH);
     }
 
-    roomRepository.deleteById(room.getId());
+    room.setStatus(RoomStatus.DELETE);
+    room.setDeletedAt(LocalDateTime.now());
+    roomRepository.save(room);
   }
 
   private void validateUpdateRoom(Room room, RoomForm form, Long userId) {

--- a/game-api/src/main/java/com/tang/game/room/service/RoomService.java
+++ b/game-api/src/main/java/com/tang/game/room/service/RoomService.java
@@ -8,6 +8,7 @@ import com.tang.game.room.domain.Room;
 import com.tang.game.room.dto.RoomForm;
 import com.tang.game.room.repository.RoomRepository;
 import com.tang.game.common.type.ErrorCode;
+import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -50,17 +51,14 @@ public class RoomService {
     Room room = roomRepository.findByIdAndStatus(roomId, RoomStatus.VALID)
             .orElseThrow(() -> new JamGameException(ErrorCode.NOT_FOUND_ROOM));
 
-    validateDeleteRoom(room.getHostUserId(), userId);
+    if (!Objects.equals(room.getHostUserId(), userId)) {
+      throw new JamGameException(ErrorCode.USER_ROOM_HOST_UN_MATCH);
+    }
 
+    room.setDeletedAt(LocalDateTime.now());
     room.setStatus(DELETE);
 
     roomRepository.save(room);
-  }
-
-  private void validateDeleteRoom(Long roomHostId, Long userId) {
-    if (!Objects.equals(roomHostId, userId)) {
-      throw new JamGameException(ErrorCode.USER_ROOM_HOST_UN_MATCH);
-    }
   }
 
   private void validateUpdateRoom(Room room, RoomForm form, Long userId) {

--- a/game-api/src/main/java/com/tang/game/room/service/RoomService.java
+++ b/game-api/src/main/java/com/tang/game/room/service/RoomService.java
@@ -1,14 +1,11 @@
 package com.tang.game.room.service;
 
-import static com.tang.game.common.type.RoomStatus.DELETE;
-
 import com.tang.game.common.exception.JamGameException;
+import com.tang.game.common.type.ErrorCode;
 import com.tang.game.common.type.RoomStatus;
 import com.tang.game.room.domain.Room;
 import com.tang.game.room.dto.RoomForm;
 import com.tang.game.room.repository.RoomRepository;
-import com.tang.game.common.type.ErrorCode;
-import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -55,10 +52,7 @@ public class RoomService {
       throw new JamGameException(ErrorCode.USER_ROOM_HOST_UN_MATCH);
     }
 
-    room.setDeletedAt(LocalDateTime.now());
-    room.setStatus(DELETE);
-
-    roomRepository.save(room);
+    roomRepository.deleteById(room.getId());
   }
 
   private void validateUpdateRoom(Room room, RoomForm form, Long userId) {

--- a/game-api/src/test/java/com/tang/game/room/service/RoomServiceTest.java
+++ b/game-api/src/test/java/com/tang/game/room/service/RoomServiceTest.java
@@ -3,7 +3,9 @@ package com.tang.game.room.service;
 import static com.tang.game.common.type.GameType.GAME_ORDER;
 import static com.tang.game.common.type.RoomStatus.DELETE;
 import static com.tang.game.common.type.TeamType.PERSONAL;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -13,11 +15,11 @@ import static org.mockito.Mockito.verify;
 
 import com.tang.game.common.exception.JamGameException;
 import com.tang.game.common.type.ErrorCode;
-import com.tang.game.common.type.RoomStatus;
 import com.tang.game.room.domain.Room;
 import com.tang.game.room.dto.RoomForm;
 import com.tang.game.room.repository.RoomRepository;
 import java.util.Optional;
+import javax.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +33,9 @@ class RoomServiceTest {
 
   @Mock
   private RoomRepository roomRepository;
+
+  @Mock
+  private EntityManager entityManager;
 
   @InjectMocks
   private RoomService roomService;
@@ -149,8 +154,9 @@ class RoomServiceTest {
   @DisplayName("성공 방 삭제")
   void successDeleteRoom() {
     //given
+    Room room = getRoom();
     given(roomRepository.findByIdAndStatus(anyLong(), any()))
-        .willReturn(Optional.ofNullable(getRoom()));
+        .willReturn(Optional.of(room));
 
     ArgumentCaptor<Room> captor = ArgumentCaptor.forClass(Room.class);
 
@@ -159,7 +165,9 @@ class RoomServiceTest {
 
     //then
     verify(roomRepository, times(1)).save(captor.capture());
+
     assertEquals(captor.getValue().getStatus(), DELETE);
+    assertNotNull(captor.getValue().getDeletedAt());
   }
 
   @Test


### PR DESCRIPTION
## 변경사항
### AS-IS
- deletedAt 데이터를 추가 했습니다.

### TO-BE
- redis lock 구현

## 테스트
- [x] 테스트 코드
- [x] API 테스트

## 현재 상황
### 상황 1번 (@SqlDelete 문제)
1. 현재는 Room 데이터를 삭제 하면 RoomService에서 deleteRoom함수에서 Room의 데이터 deletedAt과 status를 직접 변경 해주고 repository.save를 해주고 있습니다. 
2. 위의 코드를 줄이기 위해 Room Entity에 @SQLDelete(sql = "UPDATE room SET deleted_at = current_timestamp, status = 'DELETE' WHERE id = ?")를 추가했습니다.
3. 그 후에 RoomService에서 deleteRoom함수에서 repository.delete만으로 데이터 값을 변경했습니다.
4. 하지만 RoomServiceTest 테스트 코드에서 Argument와 verify를 사용해서 delete 하는 순간 데이터 변경하는 것을 가져오고 싶었지만 잘 해결이 되지 않습니다.
5. 따라서 @SqlDelete를 사용하지 않고 추후에 테스트 코드를 작성할 수 있다면 사용하기로 했습니다!


### 상황 2번 (deletedAt 문제)
1. 현재 Room Entity가 BaseEntity Enttity를 상속 받아서 공통된 값 createdAt, modifiedAt을 상속 받고 사용하고 있습니다.
2. 하지만 현재 @Setter, @Getter 어노테이션을 BaseEntity에 추가하여 사용하고 있는데 get, set 메소드를 사용하면 cannot find symbol 나와서 deletedAt을 Room Entity에 추가하여 사용하고 있습니다!
3. 현재 BaseEntity에 추가하는 @MappedSuperclass 어노테이션에 의한 문제라고 추측하고 있어서 @MappedSuperclass 에 대해서 알아보고 있는 중입니다.
4. 따라서 현재는 Room Entity에 직접 deletedAt을 추가하여 사용하고 있습니다.



