### PR TITLE
채팅 멀티 모듈 생성 및 멀티 DataSource 적용

### DIFF
--- a/chat-api/build.gradle
+++ b/chat-api/build.gradle
@@ -5,8 +5,8 @@ plugins {
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
-group = 'com.tang.game'
-version = '0.0.1-SNAPSHOT'
+group 'com.tang.chat'
+version '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 configurations {
@@ -27,6 +27,7 @@ ext {
 
 dependencies {
     implementation project(':core')
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
@@ -37,12 +38,14 @@ dependencies {
 
     annotationProcessor 'org.projectlombok:lombok'
 
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
-    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 
-    implementation 'org.springframework.data:spring-data-envers'
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 }
 
 tasks.named('test') {

--- a/chat-api/src/main/java/com/tang/chat/ChatApiApplication.java
+++ b/chat-api/src/main/java/com/tang/chat/ChatApiApplication.java
@@ -1,0 +1,12 @@
+package com.tang.chat;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ChatApiApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(ChatApiApplication.class, args);
+  }
+}

--- a/chat-api/src/main/java/com/tang/chat/config/ChatDataSourceConfig.java
+++ b/chat-api/src/main/java/com/tang/chat/config/ChatDataSourceConfig.java
@@ -1,0 +1,61 @@
+package com.tang.chat.config;
+
+import com.tang.chat.domain.Chat;
+import com.zaxxer.hikari.HikariDataSource;
+import java.util.Objects;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableTransactionManagement
+@EnableJpaRepositories(
+    basePackages = "com.tang.chat.repository.chat",
+    entityManagerFactoryRef = "chatEntityManager",
+    transactionManagerRef = "chatTransactionManager"
+)
+public class ChatDataSourceConfig {
+  @Bean
+  @Primary
+  @ConfigurationProperties("datasource.chat")
+  public DataSourceProperties chatDataSourceProperties() {
+    return new DataSourceProperties();
+  }
+
+  @Bean
+  @Primary
+  public DataSource chatDataSource() {
+    return chatDataSourceProperties()
+        .initializeDataSourceBuilder()
+        .type(HikariDataSource.class)
+        .build();
+  }
+
+  @Bean(name = "chatEntityManager")
+  @Primary
+  public LocalContainerEntityManagerFactoryBean chatEntityManager(
+      EntityManagerFactoryBuilder builder
+  ) {
+    return builder.dataSource(chatDataSource()).packages(Chat.class)
+        .build();
+  }
+
+  @Bean(name = "chatTransactionManager")
+  @Primary
+  public PlatformTransactionManager chatTransactionManager(
+      @Qualifier("chatEntityManager")
+      LocalContainerEntityManagerFactoryBean entityManagerFactoryBean
+  ) {
+    return new JpaTransactionManager(Objects.requireNonNull(entityManagerFactoryBean.getObject()));
+  }
+}

--- a/chat-api/src/main/java/com/tang/chat/config/DictionaryDataSourceConfig.java
+++ b/chat-api/src/main/java/com/tang/chat/config/DictionaryDataSourceConfig.java
@@ -1,0 +1,61 @@
+package com.tang.chat.config;
+
+import com.tang.chat.domain.Dictionary;
+import com.zaxxer.hikari.HikariDataSource;
+import java.util.Objects;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableTransactionManagement
+@EnableJpaRepositories(
+    basePackages = "com.tang.chat.repository.dictionary",
+    entityManagerFactoryRef = "chatEntityManager",
+    transactionManagerRef = "chatTransactionManager"
+)
+public class DictionaryDataSourceConfig {
+  @Bean
+  @Primary
+  @ConfigurationProperties("datasource.dictionary")
+  public DataSourceProperties dictionaryDataSourceProperties() {
+    return new DataSourceProperties();
+  }
+
+  @Bean
+  @Primary
+  public DataSource dictionaryDataSource() {
+    return dictionaryDataSourceProperties()
+        .initializeDataSourceBuilder()
+        .type(HikariDataSource.class)
+        .build();
+  }
+
+  @Bean(name = "dictionaryEntityManager")
+  @Primary
+  public LocalContainerEntityManagerFactoryBean dictionaryEntityManager(
+      EntityManagerFactoryBuilder builder
+  ) {
+    return builder.dataSource(dictionaryDataSource()).packages(Dictionary.class)
+        .build();
+  }
+
+  @Bean(name = "dictionaryTransactionManager")
+  @Primary
+  public PlatformTransactionManager dictionaryTransactionManager(
+      @Qualifier("dictionaryEntityManager")
+      LocalContainerEntityManagerFactoryBean entityManagerFactoryBean
+  ) {
+    return new JpaTransactionManager(Objects.requireNonNull(entityManagerFactoryBean.getObject()));
+  }
+}

--- a/chat-api/src/main/java/com/tang/chat/domain/Chat.java
+++ b/chat-api/src/main/java/com/tang/chat/domain/Chat.java
@@ -1,0 +1,5 @@
+package com.tang.chat.domain;
+
+public class Chat {
+
+}

--- a/chat-api/src/main/java/com/tang/chat/domain/Dictionary.java
+++ b/chat-api/src/main/java/com/tang/chat/domain/Dictionary.java
@@ -1,0 +1,5 @@
+package com.tang.chat.domain;
+
+public class Dictionary {
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name = 'jam'
 include 'game-api'
 include 'core'
+include 'chat-api'
 


### PR DESCRIPTION
## 변경사항
### AS-IS
1. 채팅 서버를 위해 채팅 멀티 모듈을 생성했습니다.
2. 채팅 서버에서는 두개의 데이터베이스를 사용하기 때문에 멀티 DataSource를 적용 했습니다.

### TO-BE
1. 채팅을 위해 WebSocket 설정
2. WebSocket을 통해 채팅 기능 구현

## 테스트
- [ ] 테스트 코드
- [ ] API 테스트

- 테스트는 해보지 않았습니다!
- 채팅 기능 구현하면서 안되는 부분을 수정할려고 하고 있습니다!

## 질문 및 토론
제가 채팅 모듈에 두개의 데이터 베이스 (chat, dictionary)를 사용하기 위해 멀티 DataSource를 적용했습니다!
제가 적용한 방법이 올바른 방법인지 혹은 현업에서 많이 사용하는 방법인지 궁금합니다!
만약 더 올바른 방법 혹은 현업에서 사용하는 방법을 알려주시면 적극적으로 반영해보고 싶습니다!