### PR TITLE
채팅 모듈 멀티 datasource 셋팅 에러 수정

### DIFF
--- a/chat-api/build.gradle
+++ b/chat-api/build.gradle
@@ -5,8 +5,8 @@ plugins {
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
-group = 'com.tang.game'
-version = '0.0.1-SNAPSHOT'
+group 'com.tang.chat'
+version '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 configurations {
@@ -27,6 +27,7 @@ ext {
 
 dependencies {
     implementation project(':core')
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
@@ -37,12 +38,14 @@ dependencies {
 
     annotationProcessor 'org.projectlombok:lombok'
 
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
-    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 
-    implementation 'org.springframework.data:spring-data-envers'
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 }
 
 tasks.named('test') {

--- a/chat-api/src/main/java/com/tang/chat/ChatApiApplication.java
+++ b/chat-api/src/main/java/com/tang/chat/ChatApiApplication.java
@@ -1,0 +1,12 @@
+package com.tang.chat;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ChatApiApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(ChatApiApplication.class, args);
+  }
+}

--- a/chat-api/src/main/java/com/tang/chat/config/ChatDataSourceConfig.java
+++ b/chat-api/src/main/java/com/tang/chat/config/ChatDataSourceConfig.java
@@ -27,7 +27,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 public class ChatDataSourceConfig {
   @Bean
   @Primary
-  @ConfigurationProperties("datasource.chat")
+  @ConfigurationProperties("spring.datasource.chat")
   public DataSourceProperties chatDataSourceProperties() {
     return new DataSourceProperties();
   }

--- a/chat-api/src/main/java/com/tang/chat/config/ChatDataSourceConfig.java
+++ b/chat-api/src/main/java/com/tang/chat/config/ChatDataSourceConfig.java
@@ -1,0 +1,61 @@
+package com.tang.chat.config;
+
+import com.tang.chat.domain.Chat;
+import com.zaxxer.hikari.HikariDataSource;
+import java.util.Objects;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableTransactionManagement
+@EnableJpaRepositories(
+    basePackages = "com.tang.chat.repository.chat",
+    entityManagerFactoryRef = "chatEntityManager",
+    transactionManagerRef = "chatTransactionManager"
+)
+public class ChatDataSourceConfig {
+  @Bean
+  @Primary
+  @ConfigurationProperties("datasource.chat")
+  public DataSourceProperties chatDataSourceProperties() {
+    return new DataSourceProperties();
+  }
+
+  @Bean
+  @Primary
+  public DataSource chatDataSource() {
+    return chatDataSourceProperties()
+        .initializeDataSourceBuilder()
+        .type(HikariDataSource.class)
+        .build();
+  }
+
+  @Bean(name = "chatEntityManager")
+  @Primary
+  public LocalContainerEntityManagerFactoryBean chatEntityManager(
+      EntityManagerFactoryBuilder builder
+  ) {
+    return builder.dataSource(chatDataSource()).packages(Chat.class)
+        .build();
+  }
+
+  @Bean(name = "chatTransactionManager")
+  @Primary
+  public PlatformTransactionManager chatTransactionManager(
+      @Qualifier("chatEntityManager")
+      LocalContainerEntityManagerFactoryBean entityManagerFactoryBean
+  ) {
+    return new JpaTransactionManager(Objects.requireNonNull(entityManagerFactoryBean.getObject()));
+  }
+}

--- a/chat-api/src/main/java/com/tang/chat/config/DictionaryDataSourceConfig.java
+++ b/chat-api/src/main/java/com/tang/chat/config/DictionaryDataSourceConfig.java
@@ -1,0 +1,61 @@
+package com.tang.chat.config;
+
+import com.tang.chat.domain.Dictionary;
+import com.zaxxer.hikari.HikariDataSource;
+import java.util.Objects;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableTransactionManagement
+@EnableJpaRepositories(
+    basePackages = "com.tang.chat.repository.dictionary",
+    entityManagerFactoryRef = "chatEntityManager",
+    transactionManagerRef = "chatTransactionManager"
+)
+public class DictionaryDataSourceConfig {
+  @Bean
+  @Primary
+  @ConfigurationProperties("datasource.dictionary")
+  public DataSourceProperties dictionaryDataSourceProperties() {
+    return new DataSourceProperties();
+  }
+
+  @Bean
+  @Primary
+  public DataSource dictionaryDataSource() {
+    return dictionaryDataSourceProperties()
+        .initializeDataSourceBuilder()
+        .type(HikariDataSource.class)
+        .build();
+  }
+
+  @Bean(name = "dictionaryEntityManager")
+  @Primary
+  public LocalContainerEntityManagerFactoryBean dictionaryEntityManager(
+      EntityManagerFactoryBuilder builder
+  ) {
+    return builder.dataSource(dictionaryDataSource()).packages(Dictionary.class)
+        .build();
+  }
+
+  @Bean(name = "dictionaryTransactionManager")
+  @Primary
+  public PlatformTransactionManager dictionaryTransactionManager(
+      @Qualifier("dictionaryEntityManager")
+      LocalContainerEntityManagerFactoryBean entityManagerFactoryBean
+  ) {
+    return new JpaTransactionManager(Objects.requireNonNull(entityManagerFactoryBean.getObject()));
+  }
+}

--- a/chat-api/src/main/java/com/tang/chat/config/DictionaryDataSourceConfig.java
+++ b/chat-api/src/main/java/com/tang/chat/config/DictionaryDataSourceConfig.java
@@ -10,7 +10,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
@@ -26,14 +25,12 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 )
 public class DictionaryDataSourceConfig {
   @Bean
-  @Primary
-  @ConfigurationProperties("datasource.dictionary")
+  @ConfigurationProperties("spring.datasource.dictionary")
   public DataSourceProperties dictionaryDataSourceProperties() {
     return new DataSourceProperties();
   }
 
   @Bean
-  @Primary
   public DataSource dictionaryDataSource() {
     return dictionaryDataSourceProperties()
         .initializeDataSourceBuilder()
@@ -42,7 +39,6 @@ public class DictionaryDataSourceConfig {
   }
 
   @Bean(name = "dictionaryEntityManager")
-  @Primary
   public LocalContainerEntityManagerFactoryBean dictionaryEntityManager(
       EntityManagerFactoryBuilder builder
   ) {
@@ -51,7 +47,6 @@ public class DictionaryDataSourceConfig {
   }
 
   @Bean(name = "dictionaryTransactionManager")
-  @Primary
   public PlatformTransactionManager dictionaryTransactionManager(
       @Qualifier("dictionaryEntityManager")
       LocalContainerEntityManagerFactoryBean entityManagerFactoryBean

--- a/chat-api/src/main/java/com/tang/chat/domain/Chat.java
+++ b/chat-api/src/main/java/com/tang/chat/domain/Chat.java
@@ -1,0 +1,5 @@
+package com.tang.chat.domain;
+
+public class Chat {
+
+}

--- a/chat-api/src/main/java/com/tang/chat/domain/Dictionary.java
+++ b/chat-api/src/main/java/com/tang/chat/domain/Dictionary.java
@@ -1,0 +1,5 @@
+package com.tang.chat.domain;
+
+public class Dictionary {
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name = 'jam'
 include 'game-api'
 include 'core'
+include 'chat-api'
 


### PR DESCRIPTION
## 변경사항
### AS-IS
1. @Primary 에 의한 에러 수정
    - multi datasource 설정시 DataSourceConfig에서 하나의 datasource만 @Primary를 설정하지 않아 발생한 에러입니다.
    - Primary 는 주된, 주요한 이라는 단어 뜻으로 가장 주가되는 datasource라는 뜻으로 최우선순위 설정하라는 어노테이션입니다! 하지만 최우선순위를 두개로 설정해서 에러가 발생했습니다.
    
2. ChatDataSourceConfig, DictionaryDataSourceConfig 에서 datasource 잘못된 경로 설정 수정

### 테스트
- [ ] 테스트 코드
- [ ] API 테스트

테스트는 어플이 잘 작동되면 되기 때문에 따로 테스트 하지 않았습니다!!