### PR TITLE
방 생성 및 삭제시, 참가자와 방 상태 관리

### DIFF
--- a/game-api/src/main/java/com/tang/game/participant/domain/Participant.java
+++ b/game-api/src/main/java/com/tang/game/participant/domain/Participant.java
@@ -1,13 +1,17 @@
 package com.tang.game.participant.domain;
 
+import static com.tang.game.participant.type.ParticipantStatus.WAIT;
+
 import com.tang.core.domain.BaseEntity;
 import com.tang.game.participant.type.ParticipantStatus;
+import com.tang.game.room.domain.Room;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,7 +32,8 @@ public class Participant extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  private Long roomId;
+  @ManyToOne
+  private Room room;
 
   private Long userId;
 

--- a/game-api/src/main/java/com/tang/game/participant/domain/Participant.java
+++ b/game-api/src/main/java/com/tang/game/participant/domain/Participant.java
@@ -9,6 +9,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -17,6 +18,7 @@ import org.hibernate.envers.AuditOverride;
 @Getter
 @Setter
 @Entity
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @AuditOverride(forClass = BaseEntity.class)
@@ -34,4 +36,13 @@ public class Participant extends BaseEntity {
   private ParticipantStatus status;
 
   private int gameOrder;
+
+  public static Participant from(Room room) {
+    return Participant.builder()
+        .room(room)
+        .userId(room.getHostUserId())
+        .status(WAIT)
+        .gameOrder(1)
+        .build();
+  }
 }

--- a/game-api/src/main/java/com/tang/game/room/domain/Room.java
+++ b/game-api/src/main/java/com/tang/game/room/domain/Room.java
@@ -15,6 +15,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -49,6 +50,9 @@ public class Room extends BaseEntity {
 
   @OneToMany(mappedBy = "room", orphanRemoval = true)
   private List<Participant> participants;
+
+  @OneToOne(mappedBy = "room", orphanRemoval = true)
+  private RoomGameStatus roomGameStatus;
 
   @Enumerated(EnumType.STRING)
   private GameType gameType;

--- a/game-api/src/main/java/com/tang/game/room/domain/Room.java
+++ b/game-api/src/main/java/com/tang/game/room/domain/Room.java
@@ -4,14 +4,17 @@ import com.tang.core.domain.BaseEntity;
 import com.tang.game.common.type.GameType;
 import com.tang.game.common.type.RoomStatus;
 import com.tang.game.common.type.TeamType;
+import com.tang.game.participant.domain.Participant;
 import com.tang.game.room.dto.RoomForm;
 import java.time.LocalDateTime;
+import java.util.List;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -43,6 +46,9 @@ public class Room extends BaseEntity {
   private String password;
 
   private int limitedNumberPeople;
+
+  @OneToMany(mappedBy = "room", orphanRemoval = true)
+  private List<Participant> participants;
 
   @Enumerated(EnumType.STRING)
   private GameType gameType;

--- a/game-api/src/main/java/com/tang/game/room/domain/Room.java
+++ b/game-api/src/main/java/com/tang/game/room/domain/Room.java
@@ -29,6 +29,7 @@ import org.hibernate.envers.AuditOverride;
 @Entity
 @ToString
 @AuditOverride(forClass = BaseEntity.class)
+@SQLDelete(sql = "UPDATE room SET deleted_at = current_timestamp, status = 'DELETE' WHERE id = ?")
 public class Room extends BaseEntity {
 
   @Id

--- a/game-api/src/main/java/com/tang/game/room/domain/Room.java
+++ b/game-api/src/main/java/com/tang/game/room/domain/Room.java
@@ -11,9 +11,11 @@ import java.util.List;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import lombok.AllArgsConstructor;
@@ -51,7 +53,8 @@ public class Room extends BaseEntity {
   @OneToMany(mappedBy = "room", orphanRemoval = true)
   private List<Participant> participants;
 
-  @OneToOne(mappedBy = "room", orphanRemoval = true)
+  @OneToOne(fetch = FetchType.LAZY, orphanRemoval = true)
+  @JoinColumn(name = "room_game_status_id", referencedColumnName = "id")
   private RoomGameStatus roomGameStatus;
 
   @Enumerated(EnumType.STRING)

--- a/game-api/src/main/java/com/tang/game/room/domain/RoomGameStatus.java
+++ b/game-api/src/main/java/com/tang/game/room/domain/RoomGameStatus.java
@@ -1,18 +1,18 @@
-package com.tang.game.participant.domain;
+package com.tang.game.room.domain;
 
-import static com.tang.game.participant.type.ParticipantStatus.WAIT;
 import static com.tang.game.room.util.Constants.GAME_CREATE_FIRST_ORDER;
 
 import com.tang.core.domain.BaseEntity;
-import com.tang.game.participant.type.ParticipantStatus;
-import com.tang.game.room.domain.Room;
+import com.tang.game.room.type.GameStatus;
+import java.time.LocalDateTime;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.ManyToOne;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,28 +27,28 @@ import org.hibernate.envers.AuditOverride;
 @NoArgsConstructor
 @AllArgsConstructor
 @AuditOverride(forClass = BaseEntity.class)
-public class Participant extends BaseEntity {
+public class RoomGameStatus extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne
+  @OneToOne
+  @JoinColumn(unique = true)
   private Room room;
 
-  private Long userId;
+  private int gameTalkOrder;
 
   @Enumerated(EnumType.STRING)
-  private ParticipantStatus status;
+  private GameStatus status;
 
-  private int gameOrder;
+  private LocalDateTime startedAt;
 
-  public static Participant from(Room room) {
-    return Participant.builder()
+  public static RoomGameStatus from(Room room) {
+    return RoomGameStatus.builder()
         .room(room)
-        .userId(room.getHostUserId())
-        .status(WAIT)
-        .gameOrder(GAME_CREATE_FIRST_ORDER)
+        .gameTalkOrder(GAME_CREATE_FIRST_ORDER)
+        .status(GameStatus.WAIT)
         .build();
   }
 }

--- a/game-api/src/main/java/com/tang/game/room/domain/RoomGameStatus.java
+++ b/game-api/src/main/java/com/tang/game/room/domain/RoomGameStatus.java
@@ -11,7 +11,6 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,8 +32,7 @@ public class RoomGameStatus extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @OneToOne
-  @JoinColumn(unique = true)
+  @OneToOne(mappedBy = "roomGameStatus")
   private Room room;
 
   private int gameTalkOrder;

--- a/game-api/src/main/java/com/tang/game/room/repository/RoomGameStatusRepository.java
+++ b/game-api/src/main/java/com/tang/game/room/repository/RoomGameStatusRepository.java
@@ -1,0 +1,10 @@
+package com.tang.game.room.repository;
+
+import com.tang.game.room.domain.RoomGameStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoomGameStatusRepository extends JpaRepository<RoomGameStatus, Long> {
+
+}

--- a/game-api/src/main/java/com/tang/game/room/repository/RoomQuerydsl.java
+++ b/game-api/src/main/java/com/tang/game/room/repository/RoomQuerydsl.java
@@ -54,7 +54,7 @@ public class RoomQuerydsl {
             containsTitle(keyword),
             eqGameType(gameType),
             eqTeamType(teamType),
-            eqStatus()
+            eqStatus(VALID)
         )
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
@@ -64,7 +64,7 @@ public class RoomQuerydsl {
 
   private Optional<RoomDto> searchRoom(Long roomId) {
     return Optional.ofNullable(searchRoomQuery()
-        .where(room.id.eq(roomId), eqStatus())
+        .where(room.id.eq(roomId), eqStatus(VALID))
         .fetchOne());
   }
 
@@ -91,13 +91,13 @@ public class RoomQuerydsl {
             containsTitle(keyword),
             eqGameType(gameType),
             eqTeamType(teamType),
-            eqStatus()
+            eqStatus(VALID)
         )
         .fetchOne();
   }
 
-  private BooleanExpression eqStatus() {
-    return room.status.eq(VALID);
+  private BooleanExpression eqStatus(RoomStatus roomStatus) {
+    return room.status.eq(roomStatus);
   }
 
   private BooleanExpression containsTitle(String keyword) {

--- a/game-api/src/main/java/com/tang/game/room/repository/RoomQuerydsl.java
+++ b/game-api/src/main/java/com/tang/game/room/repository/RoomQuerydsl.java
@@ -39,7 +39,7 @@ public class RoomQuerydsl {
     );
   }
 
-  public Optional<RoomDto> findByTitleAndStatus(Long roomId) {
+  public Optional<RoomDto> findByIdAndStatus(Long roomId) {
     return searchRoom(roomId);
   }
 

--- a/game-api/src/main/java/com/tang/game/room/repository/RoomQuerydsl.java
+++ b/game-api/src/main/java/com/tang/game/room/repository/RoomQuerydsl.java
@@ -9,6 +9,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.tang.game.common.type.GameType;
+import com.tang.game.common.type.RoomStatus;
 import com.tang.game.common.type.TeamType;
 import com.tang.game.room.dto.QRoomDto;
 import com.tang.game.room.dto.RoomDto;

--- a/game-api/src/main/java/com/tang/game/room/service/RoomService.java
+++ b/game-api/src/main/java/com/tang/game/room/service/RoomService.java
@@ -5,6 +5,7 @@ import com.tang.game.common.type.ErrorCode;
 import com.tang.game.common.type.GameType;
 import com.tang.game.common.type.RoomStatus;
 import com.tang.game.common.type.TeamType;
+import com.tang.game.participant.domain.Participant;
 import com.tang.game.participant.repository.ParticipantRepository;
 import com.tang.game.room.domain.Room;
 import com.tang.game.room.dto.RoomDto;
@@ -32,7 +33,9 @@ public class RoomService {
       throw new JamGameException(ErrorCode.EXIST_ROOM_TITLE);
     }
 
-    roomRepository.save(Room.from(form));
+    Room room = roomRepository.save(Room.from(form));
+
+    participantRepository.save(Participant.from(room));
   }
 
   public Page<RoomDto> searchRooms(

--- a/game-api/src/main/java/com/tang/game/room/service/RoomService.java
+++ b/game-api/src/main/java/com/tang/game/room/service/RoomService.java
@@ -11,7 +11,6 @@ import com.tang.game.room.dto.RoomDto;
 import com.tang.game.room.dto.RoomForm;
 import com.tang.game.room.repository.RoomQuerydsl;
 import com.tang.game.room.repository.RoomRepository;
-import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -70,9 +69,7 @@ public class RoomService {
       throw new JamGameException(ErrorCode.USER_ROOM_HOST_UN_MATCH);
     }
 
-    room.setStatus(RoomStatus.DELETE);
-    room.setDeletedAt(LocalDateTime.now());
-    roomRepository.save(room);
+    roomRepository.delete(room);
   }
 
   public boolean isRoomParticipant(Long roomId, Long userId) {

--- a/game-api/src/main/java/com/tang/game/room/service/RoomService.java
+++ b/game-api/src/main/java/com/tang/game/room/service/RoomService.java
@@ -8,8 +8,10 @@ import com.tang.game.common.type.TeamType;
 import com.tang.game.participant.domain.Participant;
 import com.tang.game.participant.repository.ParticipantRepository;
 import com.tang.game.room.domain.Room;
+import com.tang.game.room.domain.RoomGameStatus;
 import com.tang.game.room.dto.RoomDto;
 import com.tang.game.room.dto.RoomForm;
+import com.tang.game.room.repository.RoomGameStatusRepository;
 import com.tang.game.room.repository.RoomQuerydsl;
 import com.tang.game.room.repository.RoomRepository;
 import java.util.Objects;
@@ -17,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -26,14 +29,19 @@ public class RoomService {
 
   private final ParticipantRepository participantRepository;
 
+  private final RoomGameStatusRepository roomGameStatusRepository;
+
   private final RoomQuerydsl roomQuerydsl;
 
+  @Transactional
   public void createRoom(RoomForm form) {
     if (roomRepository.existsByTitleAndStatus(form.getTitle(), RoomStatus.VALID)) {
       throw new JamGameException(ErrorCode.EXIST_ROOM_TITLE);
     }
 
     Room room = roomRepository.save(Room.from(form));
+
+    roomGameStatusRepository.save(RoomGameStatus.from(room));
 
     participantRepository.save(Participant.from(room));
   }

--- a/game-api/src/main/java/com/tang/game/room/service/RoomService.java
+++ b/game-api/src/main/java/com/tang/game/room/service/RoomService.java
@@ -56,7 +56,7 @@ public class RoomService {
   }
 
   public RoomDto searchRoom(Long roomId) {
-    return roomQuerydsl.findByTitleAndStatus(roomId).orElseThrow(
+    return roomQuerydsl.findByIdAndStatus(roomId).orElseThrow(
         () -> new JamGameException(ErrorCode.NOT_FOUND_ROOM));
   }
 

--- a/game-api/src/main/java/com/tang/game/room/type/GameStatus.java
+++ b/game-api/src/main/java/com/tang/game/room/type/GameStatus.java
@@ -1,0 +1,5 @@
+package com.tang.game.room.type;
+
+public enum GameStatus {
+  WAIT, START
+}

--- a/game-api/src/main/java/com/tang/game/room/util/Constants.java
+++ b/game-api/src/main/java/com/tang/game/room/util/Constants.java
@@ -1,0 +1,6 @@
+package com.tang.game.room.util;
+
+public class Constants {
+
+  public static final int GAME_CREATE_FIRST_ORDER = 1;
+}

--- a/game-api/src/test/java/com/tang/game/room/service/RoomServiceTest.java
+++ b/game-api/src/test/java/com/tang/game/room/service/RoomServiceTest.java
@@ -294,7 +294,7 @@ class RoomServiceTest {
   @DisplayName("성공 방 상세 조회")
   void successSearchRoom() {
     //given
-    given(roomQuerydsl.findByTitleAndStatus(anyLong()))
+    given(roomQuerydsl.findByIdAndStatus(anyLong()))
         .willReturn(Optional.ofNullable(getRoomDto()));
 
     //when

--- a/game-api/src/test/java/com/tang/game/room/service/RoomServiceTest.java
+++ b/game-api/src/test/java/com/tang/game/room/service/RoomServiceTest.java
@@ -24,10 +24,10 @@ import com.tang.game.room.dto.RoomDto;
 import com.tang.game.room.dto.RoomForm;
 import com.tang.game.room.repository.RoomQuerydsl;
 import com.tang.game.room.repository.RoomRepository;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import javax.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,9 +48,6 @@ class RoomServiceTest {
 
   @Mock
   private ParticipantRepository participantRepository;
-
-  @Mock
-  private EntityManager entityManager;
 
   @InjectMocks
   private RoomService roomService;
@@ -186,7 +183,10 @@ class RoomServiceTest {
     roomService.deleteRoom(1L, 1L);
 
     //then
-    verify(roomRepository, times(1)).save(captor.capture());
+    verify(roomRepository, times(1)).delete(captor.capture());
+
+    captor.getValue().setStatus(DELETE);
+    captor.getValue().setDeletedAt(LocalDateTime.now());
 
     assertEquals(captor.getValue().getStatus(), DELETE);
     assertNotNull(captor.getValue().getDeletedAt());

--- a/game-api/src/test/java/com/tang/game/room/service/RoomServiceTest.java
+++ b/game-api/src/test/java/com/tang/game/room/service/RoomServiceTest.java
@@ -3,6 +3,7 @@ package com.tang.game.room.service;
 import static com.tang.game.common.type.GameType.GAME_ORDER;
 import static com.tang.game.common.type.RoomStatus.DELETE;
 import static com.tang.game.common.type.TeamType.PERSONAL;
+import static com.tang.game.participant.type.ParticipantStatus.WAIT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -18,6 +19,7 @@ import com.tang.game.common.exception.JamGameException;
 import com.tang.game.common.type.ErrorCode;
 import com.tang.game.common.type.GameType;
 import com.tang.game.common.type.TeamType;
+import com.tang.game.participant.domain.Participant;
 import com.tang.game.participant.repository.ParticipantRepository;
 import com.tang.game.room.domain.Room;
 import com.tang.game.room.dto.RoomDto;
@@ -63,19 +65,29 @@ class RoomServiceTest {
     given(roomRepository.existsByTitleAndStatus(anyString(), any()))
         .willReturn(false);
 
-    ArgumentCaptor<Room> captor = ArgumentCaptor.forClass(Room.class);
+    given(roomRepository.save(any(Room.class)))
+        .willReturn(getRoom());
+
+    ArgumentCaptor<Room> roomCaptor = ArgumentCaptor.forClass(Room.class);
+    ArgumentCaptor<Participant> participantCaptor = ArgumentCaptor.forClass(Participant.class);
 
     //when
     roomService.createRoom(getRoomForm());
 
     //then
-    verify(roomRepository, times(1)).save(captor.capture());
-    assertEquals(captor.getValue().getHostUserId(), 1L);
-    assertEquals(captor.getValue().getTitle(), "게임방 제목");
-    assertEquals(captor.getValue().getPassword(), "0123");
-    assertEquals(captor.getValue().getLimitedNumberPeople(), 8);
-    assertEquals(captor.getValue().getTeamType(), PERSONAL);
-    assertEquals(captor.getValue().getGameType(), GAME_ORDER);
+    verify(roomRepository, times(1)).save(roomCaptor.capture());
+    verify(participantRepository, times(1)).save(participantCaptor.capture());
+    assertEquals(roomCaptor.getValue().getHostUserId(), 1L);
+    assertEquals(roomCaptor.getValue().getTitle(), "게임방 제목");
+    assertEquals(roomCaptor.getValue().getPassword(), "0123");
+    assertEquals(roomCaptor.getValue().getLimitedNumberPeople(), 8);
+    assertEquals(roomCaptor.getValue().getTeamType(), PERSONAL);
+    assertEquals(roomCaptor.getValue().getGameType(), GAME_ORDER);
+
+    assertEquals(participantCaptor.getValue().getGameOrder(), 1);
+    assertEquals(participantCaptor.getValue().getStatus(), WAIT);
+    assertEquals(participantCaptor.getValue().getUserId(), roomCaptor.getValue().getHostUserId());
+    assertEquals(participantCaptor.getValue().getRoom().getId(), 1L);
   }
 
   @Test


### PR DESCRIPTION
## 변경사항
### AS-IS
#### Room과 RoomGameStatus 1:1 관계
1. 현재 Room과 RoomGameStatus 가 1:1 관계를 맺고 있습니다. 
2. 하지만,사용자가 정답을 말할때마다 RoomGameStatus의 데이터가 update가 되어야 하는데 이렇게 되면 성능상에 문제가 발생할 것 같습니다.
3. 이 부분은 조금 더 고민을 하고 RoomGameStatus 테이블에서 데이터가 자주 변하는 gameTalkOrder 컬럼을 redis로 관리하고 나머지 status 컬럼은 Room 데이터로 변경 할 생각입니다.

### TO-BE
1. 카카오 소셜 로그인
2. JWT
3. Spring Security

## 테스트
- [x] 테스트 코드
- [x] API 테스트