### PR TITLE
Security + jwt + oauth2 기능 구현중 리뷰 피드백 적용

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     implementation 'org.projectlombok:lombok:1.18.22'
+    annotationProcessor 'org.projectlombok:lombok'
 
     implementation "com.querydsl:querydsl-jpa:5.0.0"
     implementation "com.querydsl:querydsl-apt:5.0.0"

--- a/core/src/main/java/com/tang/core/type/Gender.java
+++ b/core/src/main/java/com/tang/core/type/Gender.java
@@ -1,0 +1,5 @@
+package com.tang.core.type;
+
+public enum Gender {
+  MALE, FEMALE
+}

--- a/core/src/main/java/com/tang/core/type/SignupPath.java
+++ b/core/src/main/java/com/tang/core/type/SignupPath.java
@@ -1,0 +1,13 @@
+package com.tang.core.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SignupPath {
+  KAKAO("kakao"),
+  JAM("jam");
+
+  private final String value;
+}

--- a/game-api/build.gradle
+++ b/game-api/build.gradle
@@ -33,6 +33,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    implementation 'com.googlecode.json-simple:json-simple:1.1.1'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/game-api/src/main/java/com/tang/game/common/type/ErrorCode.java
+++ b/game-api/src/main/java/com/tang/game/common/type/ErrorCode.java
@@ -9,12 +9,23 @@ public enum ErrorCode {
   // common
   INTERNAL_SERVER_ERROR("내부 서버 오류가 발생 했습니다."),
   INVALID_REQUEST("잘못된 요청입니다."),
-  USER_NOT_FOUND("사용자가 없습니다."),
+  USER_NOT_FOUND("존재하지 않는 사용자입니다."),
 
   // Room
   USER_ROOM_HOST_UN_MATCH("게임방 주인이 아닙니다."),
   NOT_FOUND_ROOM("존재하지 않는 방입니다."),
-  EXIST_ROOM_TITLE("중복된 방 제목입니다.");
+  EXIST_ROOM_TITLE("중복된 방 제목입니다."),
+
+  // jwt
+  NOT_FOUND_TOKEN_MATCHING_USER("해당 유저에 매칭되는 토큰을 찾을 수 없습니다."),
+  EXPIRE_REFRESH_TOKEN("기간이 만료된 토큰입니다."),
+  NOT_FOUND_REFRESH_TOKEN("존재하지 않는 토큰입니다."),
+
+  // oauth
+  OAUTH_SING_UP_REQUIRE_EMAIL("이메일 동의가 반드시 필요합니다."),
+  DELETE_YET_REMAIN_7DAYS("탈퇴 한지 7일을 넘지 않았습니다. (탈퇴 철회 필요)"),
+
+  ;
 
   private final String description;
 }

--- a/game-api/src/main/java/com/tang/game/config/ApplicationConfig.java
+++ b/game-api/src/main/java/com/tang/game/config/ApplicationConfig.java
@@ -1,0 +1,19 @@
+package com.tang.game.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class ApplicationConfig {
+
+  @Bean
+  public WebClient webClient() {
+    return WebClient.builder()
+        .defaultHeader(HttpHeaders.CONTENT_TYPE,
+            MediaType.APPLICATION_JSON_VALUE)
+        .build();
+  }
+}

--- a/game-api/src/main/java/com/tang/game/config/SecurityConfig.java
+++ b/game-api/src/main/java/com/tang/game/config/SecurityConfig.java
@@ -1,0 +1,79 @@
+package com.tang.game.config;
+
+import com.tang.game.token.filter.JwtAuthenticationFilter;
+import com.tang.game.user.type.UserStatus;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@EnableWebSecurity
+@RequiredArgsConstructor
+@Configuration
+public class SecurityConfig {
+
+  private final JwtAuthenticationFilter authenticationFilter;
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+        .cors().configurationSource(getCorsConfigSource())
+        .and()
+        .csrf().disable()
+        .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        .and()
+        .httpBasic().disable()
+
+        .authorizeRequests()
+
+        .antMatchers("/oauth2/kakao/**", "/tokens/refresh/**", "/login", "/logout", "/withdrawal")
+        .permitAll()
+        .antMatchers("/**").hasAuthority(UserStatus.VALID.getKey())
+        .and()
+        .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class)
+        .logout()
+        .and()
+    ;
+
+    return http.build();
+  }
+
+  @Bean
+  public CorsConfigurationSource getCorsConfigSource() {
+    CorsConfiguration config = new CorsConfiguration();
+
+    config.setAllowCredentials(true);
+
+    config.setAllowedOrigins(Arrays.asList(
+        "http://localhost:8081",
+        "http://127.0.0.1:8081",
+        "http://localhost:63343",
+        "http://127.0.0.1:63343"
+    ));
+    config.setAllowedMethods(Arrays.asList(
+        HttpMethod.GET.name(),
+        HttpMethod.POST.name(),
+        HttpMethod.DELETE.name(),
+        HttpMethod.PUT.name(),
+        HttpMethod.HEAD.name(),
+        HttpMethod.OPTIONS.name()
+    ));
+
+    config.setAllowedHeaders(List.of("*"));
+    config.setExposedHeaders(List.of("*"));
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", config);
+    return source;
+  }
+}

--- a/game-api/src/main/java/com/tang/game/oauth/kakao/controller/Oauth2KakaoController.java
+++ b/game-api/src/main/java/com/tang/game/oauth/kakao/controller/Oauth2KakaoController.java
@@ -1,0 +1,42 @@
+package com.tang.game.oauth.kakao.controller;
+
+import com.tang.game.oauth.kakao.service.Oauth2KakaoService;
+import com.tang.game.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/oauth2/kakao")
+public class Oauth2KakaoController {
+
+  private final Oauth2KakaoService oauth2KakaoService;
+
+  @GetMapping("/code")
+  public ResponseEntity<String> getCode(@RequestParam String code) {
+    return ResponseEntity.ok(code);
+  }
+
+  @GetMapping("/login")
+  public ResponseEntity<?> login(@RequestParam String code) {
+    return ResponseEntity.ok()
+        .header(HttpHeaders.AUTHORIZATION, oauth2KakaoService.login(code).toString())
+        .build();
+  }
+
+  @GetMapping("/logout")
+  public void logoutKakao(@AuthenticationPrincipal User user) {
+    oauth2KakaoService.logout(user.getId());
+  }
+
+  @GetMapping("/unlink")
+  public void logoutKakao2(@AuthenticationPrincipal User user) {
+    oauth2KakaoService.unlink(user.getId());
+  }
+}

--- a/game-api/src/main/java/com/tang/game/oauth/kakao/controller/Oauth2KakaoController.java
+++ b/game-api/src/main/java/com/tang/game/oauth/kakao/controller/Oauth2KakaoController.java
@@ -31,12 +31,12 @@ public class Oauth2KakaoController {
   }
 
   @GetMapping("/logout")
-  public void logoutKakao(@AuthenticationPrincipal User user) {
+  public void logout(@AuthenticationPrincipal User user) {
     oauth2KakaoService.logout(user.getId());
   }
 
   @GetMapping("/unlink")
-  public void logoutKakao2(@AuthenticationPrincipal User user) {
+  public void unlink(@AuthenticationPrincipal User user) {
     oauth2KakaoService.unlink(user.getId());
   }
 }

--- a/game-api/src/main/java/com/tang/game/oauth/kakao/dto/KakaoAccount.java
+++ b/game-api/src/main/java/com/tang/game/oauth/kakao/dto/KakaoAccount.java
@@ -1,0 +1,52 @@
+package com.tang.game.oauth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoAccount {
+  @JsonProperty("profile_nickname_needs_agreement")
+  private boolean profileNicknameNeedsAgreement;
+
+  @JsonProperty("profile")
+  private KakaoProfile kakaoProfile;
+
+  @JsonProperty("has_email")
+  private boolean hasEmail;
+
+  @JsonProperty("email_needs_agreement")
+  private boolean emailNeedsAgreement;
+
+  @JsonProperty("is_email_valid")
+  private boolean isEmailValid;
+
+  @JsonProperty("is_email_verified")
+  private boolean isEmailVerified;
+
+  @JsonProperty("email")
+  private String email;
+
+  @JsonProperty("has_age_range")
+  private boolean hasAgeRange;
+
+  @JsonProperty("age_range_needs_agreement")
+  private boolean ageRangeNeedsAgreement;
+
+  @JsonProperty("age_range")
+  private String ageRange;
+
+  @JsonProperty("has_gender")
+  private boolean hasGender;
+
+  @JsonProperty("gender_needs_agreement")
+  private boolean genderNeedsAgreement;
+
+  @JsonProperty("gender")
+  private String gender;
+}

--- a/game-api/src/main/java/com/tang/game/oauth/kakao/dto/KakaoOauthTokenAndScope.java
+++ b/game-api/src/main/java/com/tang/game/oauth/kakao/dto/KakaoOauthTokenAndScope.java
@@ -1,0 +1,39 @@
+package com.tang.game.oauth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+public class KakaoOauthTokenAndScope {
+
+  @Getter
+  @Setter
+  @Builder
+  @ToString
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Response {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("scope")
+    private String scope;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("refresh_token_expires_in")
+    private int refreshTokenExpiresIn;
+
+    @JsonProperty("expires_in")
+    private int expiresIn;
+  }
+}

--- a/game-api/src/main/java/com/tang/game/oauth/kakao/dto/KakaoOauthUserInfo.java
+++ b/game-api/src/main/java/com/tang/game/oauth/kakao/dto/KakaoOauthUserInfo.java
@@ -1,0 +1,31 @@
+package com.tang.game.oauth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+public class KakaoOauthUserInfo {
+  @Getter
+  @Setter
+  @Builder
+  @ToString
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class Response {
+
+    @JsonProperty("id")
+    private Long id;
+
+    @JsonProperty("connected_at")
+    private String connectedAt;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+  }
+}

--- a/game-api/src/main/java/com/tang/game/oauth/kakao/dto/KakaoProfile.java
+++ b/game-api/src/main/java/com/tang/game/oauth/kakao/dto/KakaoProfile.java
@@ -1,0 +1,16 @@
+package com.tang.game.oauth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoProfile {
+  @JsonProperty("nickname")
+  private String nickname;
+}

--- a/game-api/src/main/java/com/tang/game/oauth/kakao/service/Oauth2KakaoService.java
+++ b/game-api/src/main/java/com/tang/game/oauth/kakao/service/Oauth2KakaoService.java
@@ -1,0 +1,237 @@
+package com.tang.game.oauth.kakao.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tang.core.type.Gender;
+import com.tang.core.type.SignupPath;
+import com.tang.game.common.exception.JamGameException;
+import com.tang.game.common.type.ErrorCode;
+import com.tang.game.token.domain.Token;
+import com.tang.game.token.dto.JwtTokenDto;
+import com.tang.game.token.repository.TokenRepository;
+import com.tang.game.token.Service.TokenProvider;
+import com.tang.game.user.domain.User;
+import com.tang.game.user.repository.UserRepository;
+import com.tang.game.user.type.UserStatus;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@RequiredArgsConstructor
+public class Oauth2KakaoService {
+
+  @Value(value = "${spring.security.oauth2.client.registration.kakao.authorization-grant-type}")
+  private String grantType;
+
+  @Value(value = "${spring.security.oauth2.client.registration.kakao.client-id}")
+  private String clientId;
+
+  @Value(value = "${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+  private String redirectUrl;
+
+  @Value(value = "${spring.security.oauth2.client.provider.kakao.token_uri}")
+  private String tokenUrl;
+
+  @Value(value = "${spring.security.oauth2.client.provider.kakao.user-info-uri}")
+  private String userInfoUrl;
+
+  private final TokenRepository tokenRepository;
+
+  private final UserRepository userRepository;
+
+  private final TokenProvider tokenProvider;
+
+  @Transactional
+  public JwtTokenDto login(String code) {
+    JSONObject kakaoTokenAndScopeJSONData = getKakaoTokenAndScopeJSONData(code);
+
+    User user = parseUserForKakaoResponse(
+        getKakaoOauthInfoJSONData(kakaoTokenAndScopeJSONData)
+    );
+
+    userRepository.save(user);
+
+    JwtTokenDto jwtTokenDto = tokenProvider.generateToken(
+        user.getEmail(),
+        user.getSignupPath(),
+        user.getId(),
+        Collections.singletonList(user.getStatus().getKey())
+    );
+
+    String accessToken = kakaoTokenAndScopeJSONData.get("access_token").toString();
+
+    tokenRepository.findByUserId(user.getId())
+        .ifPresentOrElse(
+            token -> {
+              token.setOauthAccessToken(accessToken);
+              token.setJwtAccessToken(jwtTokenDto.getJwtAccessToken());
+              token.setJwtRefreshToken(jwtTokenDto.getJwtRefreshToken());
+            },
+            () -> tokenRepository.save(Token.of(user.getId(), jwtTokenDto, accessToken))
+        );
+
+    return jwtTokenDto;
+  }
+
+  private User parseUserForKakaoResponse(JSONObject kakaoOauthInfoJSONData) {
+    String nickname = null;
+    String email = null;
+    String ageRange = null;
+    Gender gender = null;
+
+    JSONParser jsonParser = new JSONParser();
+    ObjectMapper mapper = new ObjectMapper();
+
+    JSONObject kakaoResponseJson = null;
+
+    try {
+      kakaoResponseJson = (JSONObject) jsonParser.parse(
+          mapper.writer().writeValueAsString(kakaoOauthInfoJSONData.get("kakao_account"))
+      );
+    } catch (ParseException | JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+
+    boolean isNickNameAgreement = !(Boolean) kakaoResponseJson
+        .get("profile_nickname_needs_agreement");
+
+    boolean isEmailAgreement = !(Boolean) kakaoResponseJson
+        .get("email_needs_agreement");
+
+    boolean isAgeRangeAgreement = !(Boolean) kakaoResponseJson
+        .get("age_range_needs_agreement");
+
+    boolean isGenderAgreement = !(Boolean) kakaoResponseJson
+        .get("gender_needs_agreement");
+
+    if (isNickNameAgreement) {
+      nickname = ((JSONObject) kakaoResponseJson.get("profile"))
+          .get("nickname").toString();
+    }
+
+    if (isEmailAgreement) {
+      email = kakaoResponseJson.get("email").toString();
+
+      Optional<User> user =
+          userRepository.findByEmailAndSignupPath(email, SignupPath.KAKAO);
+
+      if (user.isPresent()) {
+        if (user.get().getStatus() == UserStatus.VALID) {
+          return user.get();
+        } else if (!user.get().getDeletedAt().isBefore(LocalDateTime.now().minusDays(7))) {
+          throw new JamGameException(ErrorCode.DELETE_YET_REMAIN_7DAYS);
+        }
+      }
+    } else {
+      unlink(kakaoResponseJson.get("access_token").toString());
+      throw new JamGameException(ErrorCode.OAUTH_SING_UP_REQUIRE_EMAIL);
+    }
+
+    if (isAgeRangeAgreement) {
+      ageRange = kakaoResponseJson.get("age_range").toString();
+    }
+
+    if (isGenderAgreement) {
+      gender = Objects.equals("male", kakaoResponseJson.get("gender")) ?
+          Gender.MALE : Gender.FEMALE;
+    }
+
+    return User.builder()
+        .email(email)
+        .nickname(nickname)
+        .gender(gender)
+        .ageRange(ageRange)
+        .status(UserStatus.VALID)
+        .signupPath(SignupPath.KAKAO)
+        .build();
+  }
+
+  private JSONObject getKakaoTokenAndScopeJSONData(String code) {
+    WebClient webClient = WebClient.builder()
+        .baseUrl(tokenUrl)
+        .defaultHeader(HttpHeaders.CONTENT_TYPE,
+            "application/x-www-form-urlencoded;charset=utf-8")
+        .build();
+
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+    params.add("grant_type", grantType);
+    params.add("client_id", clientId);
+    params.add("redirect_uri", redirectUrl);
+    params.add("code", code);
+
+    return webClient
+        .post()
+        .bodyValue(params)
+        .retrieve()
+        .bodyToMono(JSONObject.class)
+        .block();
+  }
+
+  private JSONObject getKakaoOauthInfoJSONData(JSONObject kakaoTokenAndScopeJSONData) {
+    String accessToken = kakaoTokenAndScopeJSONData.get("access_token").toString();
+
+    System.out.println(accessToken);
+    WebClient webClient = WebClient.builder()
+        .baseUrl(userInfoUrl)
+        .defaultHeaders(headers -> {
+          headers.add(HttpHeaders.CONTENT_TYPE,
+              "application/x-www-form-urlencoded;charset=utf-8");
+          headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+        })
+        .build();
+
+    return webClient
+        .post()
+        .retrieve()
+        .bodyToMono(JSONObject.class)
+        .block();
+  }
+
+  public void logout(Long userId) {
+    webClientPostWithAuthorization("https://kapi.kakao.com/v1/user/logout",
+        "Bearer " + getOauthAccessToken(userId));
+  }
+
+  public void unlink(Long userId) {
+    unlink(getOauthAccessToken(userId));
+  }
+
+  private void unlink(String token) {
+    webClientPostWithAuthorization("https://kapi.kakao.com/v1/user/unlink",
+        "Bearer " + token);
+  }
+
+  private String getOauthAccessToken(Long userId) {
+    Token token = tokenRepository.findByUserId(userId)
+        .orElseThrow(() -> new JamGameException(ErrorCode.USER_NOT_FOUND));
+
+    return token.getOauthAccessToken();
+  }
+
+  private void webClientPostWithAuthorization(String url, String authorization) {
+    WebClient.builder()
+        .baseUrl("https://kapi.kakao.com/v1/user/unlink")
+        .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        .build()
+        .post()
+        .header(HttpHeaders.AUTHORIZATION, authorization)
+        .retrieve()
+        .bodyToMono(JSONObject.class)
+        .block();
+  }
+}

--- a/game-api/src/main/java/com/tang/game/token/Service/TokenProvider.java
+++ b/game-api/src/main/java/com/tang/game/token/Service/TokenProvider.java
@@ -1,0 +1,118 @@
+package com.tang.game.token.Service;
+
+import static com.tang.game.token.utils.Constants.KEY_ROLES;
+import static com.tang.game.token.utils.Constants.TOKEN_PREFIX;
+
+import com.tang.core.type.SignupPath;
+import com.tang.game.common.exception.JamGameException;
+import com.tang.game.common.type.ErrorCode;
+import com.tang.game.token.dto.JwtTokenDto;
+import com.tang.game.user.domain.User;
+import com.tang.game.user.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@RequiredArgsConstructor
+public class TokenProvider {
+
+  private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24; // 1 hour
+
+  private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 30L; //30일
+
+  private final UserRepository userRepository;
+
+  @Value("${spring.jwt.secret}")
+  private String secretKey;
+
+  public JwtTokenDto generateToken(
+      String email,
+      SignupPath signupPath,
+      Long id,
+      List<String> roles
+  ) {
+    Claims claims = Jwts.claims()
+        .setSubject(signupPath + "&&" + email)
+        .setId(id.toString());
+    claims.put(KEY_ROLES, roles);
+
+    Date now = new Date();
+    Date accessTokenExpiredDate = new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_TIME);
+    Date refreshTokenExpiredDate = new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_TIME);
+
+    return JwtTokenDto.builder()
+        .grantType(TOKEN_PREFIX)
+        .jwtAccessToken(getToken(claims, now, accessTokenExpiredDate))
+        .jwtRefreshToken(getToken(claims, now, refreshTokenExpiredDate))
+        .jwtAccessTokenExpiresTime(accessTokenExpiredDate)
+        .jwtRefreshTokenExpiresTime(refreshTokenExpiredDate)
+        .build();
+  }
+
+  public String newGenerateAccessToken(User user) {
+    Claims claims = Jwts.claims()
+        .setSubject(user.getSignupPath() + "&&" + user.getEmail())
+        .setId(user.getId().toString());
+    claims.put(KEY_ROLES, Collections.singletonList(user.getStatus().getKey()));
+
+    Date now = new Date();
+    Date accessTokenExpiredDate = new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_TIME);
+
+    return getToken(claims, now, accessTokenExpiredDate);
+  }
+
+  private String getToken(Claims claims, Date now, Date tokenExpiredDate) {
+    return Jwts.builder()
+        .setClaims(claims)
+        .setIssuedAt(now)
+        .setExpiration(tokenExpiredDate)
+        .signWith(SignatureAlgorithm.HS512, this.secretKey)
+        .compact();
+  }
+
+  public Authentication getAuthentication(String token) {
+    String[] signupPathAndEmail = getSignupPathAndEmail(token).split("&&", 2);
+
+    UserDetails userDetails = this.userRepository.findByEmailAndSignupPath(
+        signupPathAndEmail[1],
+        SignupPath.valueOf(signupPathAndEmail[0])
+    ).orElseThrow(() -> new JamGameException(ErrorCode.USER_NOT_FOUND));
+
+    return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+  }
+
+  public String getSignupPathAndEmail(String token) {
+    return this.parseClaims(token).getSubject();
+  }
+
+  public boolean validateToken(String token) {
+    if (!StringUtils.hasText(token)) {
+      return false;
+    }
+
+    return !this.parseClaims(token)
+        .getExpiration()
+        .before(new Date());
+  }
+
+  private Claims parseClaims(String token) {
+    try {
+      return Jwts.parser().setSigningKey(this.secretKey).parseClaimsJws(token).getBody();
+    } catch (ExpiredJwtException e) {
+      return e.getClaims();
+    }
+  }
+
+}

--- a/game-api/src/main/java/com/tang/game/token/Service/TokenService.java
+++ b/game-api/src/main/java/com/tang/game/token/Service/TokenService.java
@@ -1,0 +1,42 @@
+package com.tang.game.token.Service;
+
+import com.tang.game.common.exception.JamGameException;
+import com.tang.game.common.type.ErrorCode;
+import com.tang.game.token.domain.Token;
+import com.tang.game.token.repository.TokenRepository;
+import com.tang.game.user.domain.User;
+import com.tang.game.user.repository.UserRepository;
+import com.tang.game.user.type.UserStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+  private final TokenProvider tokenProvider;
+
+  private final TokenRepository tokenRepository;
+
+  private final UserRepository userRepository;
+
+  public String tokenRefresh(String accessToken, String refreshToken) {
+    Token token = tokenRepository.findByJwtRefreshToken(refreshToken)
+        .orElseThrow(() -> new JamGameException(ErrorCode.NOT_FOUND_REFRESH_TOKEN));
+
+    if (!tokenProvider.validateToken(refreshToken)) {
+      throw new JamGameException(ErrorCode.EXPIRE_REFRESH_TOKEN);
+    }
+
+    User user = userRepository.findByIdAndStatus(token.getUserId(), UserStatus.VALID)
+        .orElseThrow(() -> new JamGameException(ErrorCode.USER_NOT_FOUND));
+
+    String newAccessToken = tokenProvider.newGenerateAccessToken(user);
+
+    token.setJwtAccessToken(newAccessToken);
+
+    tokenRepository.save(token);
+
+    return newAccessToken;
+  }
+}

--- a/game-api/src/main/java/com/tang/game/token/controller/TokenController.java
+++ b/game-api/src/main/java/com/tang/game/token/controller/TokenController.java
@@ -1,0 +1,28 @@
+package com.tang.game.token.controller;
+
+import com.tang.game.token.Service.TokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/tokens")
+@RequiredArgsConstructor
+public class TokenController {
+
+  private final TokenService tokenService;
+
+  @GetMapping("/refresh")
+  public ResponseEntity<?> refreshToken(
+      @RequestHeader(name = "ACCESS_TOKEN") String accessToken,
+      @RequestHeader(name = "REFRESH_TOKEN") String refreshToken
+  ) {
+    return ResponseEntity.ok().header(
+        "ACCESS_TOKEN",
+        tokenService.tokenRefresh(accessToken, refreshToken)
+    ).build();
+  }
+}

--- a/game-api/src/main/java/com/tang/game/token/domain/Token.java
+++ b/game-api/src/main/java/com/tang/game/token/domain/Token.java
@@ -1,0 +1,50 @@
+package com.tang.game.token.domain;
+
+import com.tang.core.domain.BaseEntity;
+import com.tang.game.token.dto.JwtTokenDto;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.envers.AuditOverride;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@AuditOverride(forClass = BaseEntity.class)
+public class Token extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(unique = true)
+  private Long userId;
+
+  private String jwtGrantType;
+
+  private String jwtAccessToken;
+
+  private String jwtRefreshToken;
+
+  private String oauthAccessToken;
+
+  public static Token of(Long userId, JwtTokenDto jwtTokenDto, String oauthAccessToken) {
+    return Token.builder()
+        .userId(userId)
+        .jwtAccessToken(jwtTokenDto.getJwtAccessToken())
+        .jwtGrantType(jwtTokenDto.getGrantType())
+        .jwtRefreshToken(jwtTokenDto.getJwtRefreshToken())
+        .oauthAccessToken(oauthAccessToken)
+        .build();
+  }
+}

--- a/game-api/src/main/java/com/tang/game/token/dto/JwtTokenDto.java
+++ b/game-api/src/main/java/com/tang/game/token/dto/JwtTokenDto.java
@@ -1,0 +1,25 @@
+package com.tang.game.token.dto;
+
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class JwtTokenDto {
+
+  private String grantType;
+  private String jwtAccessToken;
+  private String jwtRefreshToken;
+  private Date jwtAccessTokenExpiresTime;
+  private Date jwtRefreshTokenExpiresTime;
+}
+

--- a/game-api/src/main/java/com/tang/game/token/filter/JwtAuthenticationFilter.java
+++ b/game-api/src/main/java/com/tang/game/token/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,53 @@
+package com.tang.game.token.filter;
+
+import static com.tang.game.token.utils.Constants.TOKEN_PREFIX;
+
+import com.tang.game.token.Service.TokenProvider;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private final TokenProvider tokenProvider;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    String token = this.resolveTokenFromRequest(request);
+
+    if (StringUtils.hasText(token) && this.tokenProvider.validateToken(token)) {
+      Authentication auth = this.tokenProvider.getAuthentication(token);
+      SecurityContextHolder.getContext().setAuthentication(auth);
+
+      log.info(String.format("[%s] -> %s", this.tokenProvider.getSignupPathAndEmail(token),
+          request.getRequestURI()));
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  private String resolveTokenFromRequest(HttpServletRequest request) {
+    String token = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+    if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
+      return token.substring(TOKEN_PREFIX.length());
+    }
+
+    return null;
+  }
+}

--- a/game-api/src/main/java/com/tang/game/token/repository/TokenRepository.java
+++ b/game-api/src/main/java/com/tang/game/token/repository/TokenRepository.java
@@ -1,0 +1,14 @@
+package com.tang.game.token.repository;
+
+import com.tang.game.token.domain.Token;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TokenRepository extends JpaRepository<Token, Long> {
+
+  Optional<Token> findByUserId(Long userId);
+
+  Optional<Token> findByJwtRefreshToken(String refreshToken);
+}

--- a/game-api/src/main/java/com/tang/game/token/utils/Constants.java
+++ b/game-api/src/main/java/com/tang/game/token/utils/Constants.java
@@ -1,0 +1,6 @@
+package com.tang.game.token.utils;
+
+public class Constants {
+    public static final String TOKEN_PREFIX = "Bearer ";
+    public static final String KEY_ROLES = "roles";
+}

--- a/game-api/src/main/java/com/tang/game/user/domain/User.java
+++ b/game-api/src/main/java/com/tang/game/user/domain/User.java
@@ -1,0 +1,105 @@
+package com.tang.game.user.domain;
+
+import com.tang.core.domain.BaseEntity;
+import com.tang.core.type.Gender;
+import com.tang.core.type.SignupPath;
+import com.tang.game.user.type.UserStatus;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.envers.AuditOverride;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@AuditOverride(forClass = BaseEntity.class)
+@ToString
+public class User extends BaseEntity implements UserDetails {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String email;
+
+  @Column(nullable = false)
+  private String nickname;
+
+  @Enumerated(EnumType.STRING)
+  private Gender gender;
+
+  private String ageRange;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private UserStatus status;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private SignupPath signupPath;
+
+  private LocalDateTime deletedAt;
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    List<String> roles = new ArrayList<>();
+
+    roles.add(this.getStatus().getKey());
+
+    return roles.stream()
+        .map(SimpleGrantedAuthority::new)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public String getPassword() {
+    return null;
+  }
+
+  @Override
+  public String getUsername() {
+    return this.nickname;
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return false;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return false;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return false;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return false;
+  }
+}

--- a/game-api/src/main/java/com/tang/game/user/repository/UserRepository.java
+++ b/game-api/src/main/java/com/tang/game/user/repository/UserRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-  Optional<User> findByEmailAndSignupPath(String email, SignupPath SignupPath);
+  Optional<User> findByEmailAndSignupPath(String email, SignupPath signupPath);
 
   Optional<User> findByIdAndStatus(Long userId, UserStatus status);
 }

--- a/game-api/src/main/java/com/tang/game/user/repository/UserRepository.java
+++ b/game-api/src/main/java/com/tang/game/user/repository/UserRepository.java
@@ -1,0 +1,15 @@
+package com.tang.game.user.repository;
+
+import com.tang.core.type.SignupPath;
+import com.tang.game.user.domain.User;
+import com.tang.game.user.type.UserStatus;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+  Optional<User> findByEmailAndSignupPath(String email, SignupPath SignupPath);
+
+  Optional<User> findByIdAndStatus(Long userId, UserStatus status);
+}

--- a/game-api/src/main/java/com/tang/game/user/type/UserStatus.java
+++ b/game-api/src/main/java/com/tang/game/user/type/UserStatus.java
@@ -1,0 +1,14 @@
+package com.tang.game.user.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserStatus {
+  VALID("VALID", "일반 회원"),
+  DELETE("DELETE", "탈퇴 회원");
+
+  private final String key;
+  private final String status;
+}


### PR DESCRIPTION
## 변경사항
### AS-IS
1.  인스턴스를 생성&초기화하는데 드는 리소스가 많이 드는 클래스 Bean으로 등록하여 사용
    - WebClient만 Bean으로 등록하여 사용하고 있습니다.
    - ObjectMapper, JSONParser는 피드백에 맞게 리팩토링하다보니 사용할 필요가 없어져서 Bean으로 등록하지 않았습니다.

2. kakaoTalk에서 응답으로 내려주는 값들을 class로 구성

### TO-BE
- 기본 로그인 로그아웃
- 회원 탈퇴
- 기존에 만들었던 controller에서 임의로 만든 유저데이터를 직접 가져오는걸로 변경

## 테스트
- [ ] 테스트 코드
- [x] API 테스트