### PR TITLE
앱 자체 로그인 로그아웃 회원탈퇴 기능 구현

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     implementation 'org.projectlombok:lombok:1.18.22'
+    annotationProcessor 'org.projectlombok:lombok'
 
     implementation "com.querydsl:querydsl-jpa:5.0.0"
     implementation "com.querydsl:querydsl-apt:5.0.0"

--- a/game-api/src/main/java/com/tang/game/common/type/ErrorCode.java
+++ b/game-api/src/main/java/com/tang/game/common/type/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
   // User
   EMAIL_OR_PASSWORD_UN_MATCH("아이디 혹은 비밀번호를 다시 확인해주세요"),
   PASSWORD_UN_MATCH("비밀번호가 일치하지 않습니다."),
+  ALREADY_EXIST_EMAIL("이미 존재하는 이메일입니다."),
 
   // Room
   USER_ROOM_HOST_UN_MATCH("게임방 주인이 아닙니다."),

--- a/game-api/src/main/java/com/tang/game/common/type/ErrorCode.java
+++ b/game-api/src/main/java/com/tang/game/common/type/ErrorCode.java
@@ -11,6 +11,10 @@ public enum ErrorCode {
   INVALID_REQUEST("잘못된 요청입니다."),
   USER_NOT_FOUND("존재하지 않는 사용자입니다."),
 
+  // User
+  EMAIL_OR_PASSWORD_UN_MATCH("아이디 혹은 비밀번호를 다시 확인해주세요"),
+  PASSWORD_UN_MATCH("비밀번호가 일치하지 않습니다."),
+
   // Room
   USER_ROOM_HOST_UN_MATCH("게임방 주인이 아닙니다."),
   NOT_FOUND_ROOM("존재하지 않는 방입니다."),

--- a/game-api/src/main/java/com/tang/game/config/ApplicationConfig.java
+++ b/game-api/src/main/java/com/tang/game/config/ApplicationConfig.java
@@ -1,0 +1,19 @@
+package com.tang.game.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class ApplicationConfig {
+
+  @Bean
+  public WebClient webClient() {
+    return WebClient.builder()
+        .defaultHeader(HttpHeaders.CONTENT_TYPE,
+            MediaType.APPLICATION_JSON_VALUE)
+        .build();
+  }
+}

--- a/game-api/src/main/java/com/tang/game/config/SecurityConfig.java
+++ b/game-api/src/main/java/com/tang/game/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -25,6 +26,11 @@ public class SecurityConfig {
   private final JwtAuthenticationFilter authenticationFilter;
 
   @Bean
+  public BCryptPasswordEncoder bCryptPasswordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+  @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http
         .cors().configurationSource(getCorsConfigSource())
@@ -36,7 +42,13 @@ public class SecurityConfig {
 
         .authorizeRequests()
 
-        .antMatchers("/oauth2/kakao/**", "/tokens/refresh/**", "/login", "/logout", "/withdrawal")
+        .antMatchers(
+            "/oauth2/kakao/**",
+            "/tokens/refresh/**",
+            "/users/signup",
+            "/users/login",
+            "/users/ckEmailOverLap"
+            )
         .permitAll()
         .antMatchers("/**").hasAuthority(UserStatus.VALID.getKey())
         .and()

--- a/game-api/src/main/java/com/tang/game/oauth/kakao/controller/Oauth2KakaoController.java
+++ b/game-api/src/main/java/com/tang/game/oauth/kakao/controller/Oauth2KakaoController.java
@@ -1,9 +1,10 @@
 package com.tang.game.oauth.kakao.controller;
 
+import static com.tang.game.token.utils.Constants.tokenResponse;
+
 import com.tang.game.oauth.kakao.service.Oauth2KakaoService;
 import com.tang.game.user.domain.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,9 +26,7 @@ public class Oauth2KakaoController {
 
   @GetMapping("/login")
   public ResponseEntity<?> login(@RequestParam String code) {
-    return ResponseEntity.ok()
-        .header(HttpHeaders.AUTHORIZATION, oauth2KakaoService.login(code).toString())
-        .build();
+    return tokenResponse(oauth2KakaoService.login(code));
   }
 
   @GetMapping("/logout")

--- a/game-api/src/main/java/com/tang/game/oauth/kakao/controller/Oauth2KakaoController.java
+++ b/game-api/src/main/java/com/tang/game/oauth/kakao/controller/Oauth2KakaoController.java
@@ -31,12 +31,12 @@ public class Oauth2KakaoController {
   }
 
   @GetMapping("/logout")
-  public void logoutKakao(@AuthenticationPrincipal User user) {
+  public void logout(@AuthenticationPrincipal User user) {
     oauth2KakaoService.logout(user.getId());
   }
 
   @GetMapping("/unlink")
-  public void logoutKakao2(@AuthenticationPrincipal User user) {
+  public void unlink(@AuthenticationPrincipal User user) {
     oauth2KakaoService.unlink(user.getId());
   }
 }

--- a/game-api/src/main/java/com/tang/game/oauth/kakao/dto/KakaoAccount.java
+++ b/game-api/src/main/java/com/tang/game/oauth/kakao/dto/KakaoAccount.java
@@ -1,0 +1,52 @@
+package com.tang.game.oauth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoAccount {
+  @JsonProperty("profile_nickname_needs_agreement")
+  private boolean profileNicknameNeedsAgreement;
+
+  @JsonProperty("profile")
+  private KakaoProfile kakaoProfile;
+
+  @JsonProperty("has_email")
+  private boolean hasEmail;
+
+  @JsonProperty("email_needs_agreement")
+  private boolean emailNeedsAgreement;
+
+  @JsonProperty("is_email_valid")
+  private boolean isEmailValid;
+
+  @JsonProperty("is_email_verified")
+  private boolean isEmailVerified;
+
+  @JsonProperty("email")
+  private String email;
+
+  @JsonProperty("has_age_range")
+  private boolean hasAgeRange;
+
+  @JsonProperty("age_range_needs_agreement")
+  private boolean ageRangeNeedsAgreement;
+
+  @JsonProperty("age_range")
+  private String ageRange;
+
+  @JsonProperty("has_gender")
+  private boolean hasGender;
+
+  @JsonProperty("gender_needs_agreement")
+  private boolean genderNeedsAgreement;
+
+  @JsonProperty("gender")
+  private String gender;
+}

--- a/game-api/src/main/java/com/tang/game/oauth/kakao/dto/KakaoOauthTokenAndScope.java
+++ b/game-api/src/main/java/com/tang/game/oauth/kakao/dto/KakaoOauthTokenAndScope.java
@@ -1,0 +1,39 @@
+package com.tang.game.oauth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+public class KakaoOauthTokenAndScope {
+
+  @Getter
+  @Setter
+  @Builder
+  @ToString
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Response {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("scope")
+    private String scope;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("refresh_token_expires_in")
+    private int refreshTokenExpiresIn;
+
+    @JsonProperty("expires_in")
+    private int expiresIn;
+  }
+}

--- a/game-api/src/main/java/com/tang/game/oauth/kakao/dto/KakaoOauthUserInfo.java
+++ b/game-api/src/main/java/com/tang/game/oauth/kakao/dto/KakaoOauthUserInfo.java
@@ -1,0 +1,31 @@
+package com.tang.game.oauth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+public class KakaoOauthUserInfo {
+  @Getter
+  @Setter
+  @Builder
+  @ToString
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class Response {
+
+    @JsonProperty("id")
+    private Long id;
+
+    @JsonProperty("connected_at")
+    private String connectedAt;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+  }
+}

--- a/game-api/src/main/java/com/tang/game/oauth/kakao/dto/KakaoProfile.java
+++ b/game-api/src/main/java/com/tang/game/oauth/kakao/dto/KakaoProfile.java
@@ -1,0 +1,16 @@
+package com.tang.game.oauth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoProfile {
+  @JsonProperty("nickname")
+  private String nickname;
+}

--- a/game-api/src/main/java/com/tang/game/oauth/kakao/service/Oauth2KakaoService.java
+++ b/game-api/src/main/java/com/tang/game/oauth/kakao/service/Oauth2KakaoService.java
@@ -1,9 +1,10 @@
 package com.tang.game.oauth.kakao.service;
 
+import static com.tang.core.type.SignupPath.KAKAO;
 import static com.tang.game.token.utils.Constants.TOKEN_PREFIX;
+import static com.tang.game.user.type.UserStatus.VALID;
 
 import com.tang.core.type.Gender;
-import com.tang.core.type.SignupPath;
 import com.tang.game.common.exception.JamGameException;
 import com.tang.game.common.type.ErrorCode;
 import com.tang.game.oauth.kakao.dto.KakaoAccount;
@@ -16,7 +17,6 @@ import com.tang.game.token.dto.JwtTokenDto;
 import com.tang.game.token.repository.TokenRepository;
 import com.tang.game.user.domain.User;
 import com.tang.game.user.repository.UserRepository;
-import com.tang.game.user.type.UserStatus;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Objects;
@@ -70,8 +70,6 @@ public class Oauth2KakaoService {
     userRepository.save(user);
 
     JwtTokenDto jwtTokenDto = tokenProvider.generateToken(
-        user.getEmail(),
-        user.getSignupPath(),
         user.getId(),
         Collections.singletonList(user.getStatus().getKey())
     );
@@ -112,10 +110,10 @@ public class Oauth2KakaoService {
           throw new JamGameException(ErrorCode.OAUTH_SING_UP_REQUIRE_EMAIL);
         });
 
-    Optional<User> user = userRepository.findByEmailAndSignupPath(email, SignupPath.KAKAO);
+    Optional<User> user = userRepository.findByEmailAndSignupPathAndStatus(email, KAKAO, VALID);
 
     if (user.isPresent()) {
-      if (user.get().getStatus() == UserStatus.VALID) {
+      if (user.get().getStatus() == VALID) {
         return user.get();
       } else if (!user.get().getDeletedAt().isBefore(LocalDateTime.now().minusDays(7))) {
         throw new JamGameException(ErrorCode.DELETE_YET_REMAIN_7DAYS);
@@ -127,8 +125,8 @@ public class Oauth2KakaoService {
         .nickname(nickname)
         .gender(gender)
         .ageRange(ageRange)
-        .status(UserStatus.VALID)
-        .signupPath(SignupPath.KAKAO)
+        .status(VALID)
+        .signupPath(KAKAO)
         .build();
   }
 

--- a/game-api/src/main/java/com/tang/game/token/Service/TokenService.java
+++ b/game-api/src/main/java/com/tang/game/token/Service/TokenService.java
@@ -35,8 +35,6 @@ public class TokenService {
 
     token.setJwtAccessToken(newAccessToken);
 
-    tokenRepository.save(token);
-
     return newAccessToken;
   }
 }

--- a/game-api/src/main/java/com/tang/game/token/domain/Token.java
+++ b/game-api/src/main/java/com/tang/game/token/domain/Token.java
@@ -38,6 +38,15 @@ public class Token extends BaseEntity {
 
   private String oauthAccessToken;
 
+  public static Token of(Long userId, JwtTokenDto jwtTokenDto) {
+    return Token.builder()
+        .userId(userId)
+        .jwtAccessToken(jwtTokenDto.getJwtAccessToken())
+        .jwtGrantType(jwtTokenDto.getGrantType())
+        .jwtRefreshToken(jwtTokenDto.getJwtRefreshToken())
+        .build();
+  }
+
   public static Token of(Long userId, JwtTokenDto jwtTokenDto, String oauthAccessToken) {
     return Token.builder()
         .userId(userId)

--- a/game-api/src/main/java/com/tang/game/token/dto/JwtTokenDto.java
+++ b/game-api/src/main/java/com/tang/game/token/dto/JwtTokenDto.java
@@ -17,9 +17,13 @@ import lombok.ToString;
 public class JwtTokenDto {
 
   private String grantType;
+
   private String jwtAccessToken;
+
   private String jwtRefreshToken;
+
   private Date jwtAccessTokenExpiresTime;
+
   private Date jwtRefreshTokenExpiresTime;
 }
 

--- a/game-api/src/main/java/com/tang/game/token/utils/Constants.java
+++ b/game-api/src/main/java/com/tang/game/token/utils/Constants.java
@@ -1,6 +1,24 @@
 package com.tang.game.token.utils;
 
+import com.tang.game.token.dto.JwtTokenDto;
+import org.springframework.http.ResponseEntity;
+
 public class Constants {
-    public static final String TOKEN_PREFIX = "Bearer ";
-    public static final String KEY_ROLES = "roles";
+
+  public static final String TOKEN_PREFIX = "Bearer ";
+  public static final String KEY_ROLES = "roles";
+
+  public static ResponseEntity<?> tokenResponse(JwtTokenDto jwtTokenDto) {
+    return ResponseEntity.ok()
+        .headers(header -> {
+          header.add("TOKEN_GRANT_TYPE", jwtTokenDto.getGrantType());
+          header.add("ACCESS_TOKEN", jwtTokenDto.getJwtAccessToken());
+          header.add("REFRESH_TOKEN", jwtTokenDto.getJwtRefreshToken());
+          header.add("ACCESS_TOKEN_EXPIRES_TIME",
+              String.valueOf(jwtTokenDto.getJwtAccessTokenExpiresTime()));
+          header.add("REFRESH_TOKEN_EXPIRES_TIME",
+              String.valueOf(jwtTokenDto.getJwtRefreshTokenExpiresTime()));
+        })
+        .build();
+  }
 }

--- a/game-api/src/main/java/com/tang/game/user/controller/UserController.java
+++ b/game-api/src/main/java/com/tang/game/user/controller/UserController.java
@@ -1,0 +1,59 @@
+package com.tang.game.user.controller;
+
+import static com.tang.game.token.utils.Constants.tokenResponse;
+
+import com.tang.game.common.exception.JamGameException;
+import com.tang.game.common.type.ErrorCode;
+import com.tang.game.user.domain.User;
+import com.tang.game.user.dto.SigninForm;
+import com.tang.game.user.dto.SignupForm;
+import com.tang.game.user.dto.UserDto;
+import com.tang.game.user.service.UserService;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserController {
+
+  private final UserService userService;
+
+  @PostMapping("/signup")
+  public void signup(@RequestBody @Valid SignupForm form) {
+    userService.signup(form);
+  }
+
+  @PostMapping("/login")
+  public ResponseEntity<?> login(@RequestBody @Valid SigninForm form) {
+    return tokenResponse(userService.login(form));
+  }
+
+  @PostMapping("/withdrawal")
+  public void withdrawal(@AuthenticationPrincipal User user) {
+    System.out.println(user);
+    if (user.getUsername() == null) {
+      throw new JamGameException(ErrorCode.USER_NOT_FOUND);
+    }
+
+    userService.withdrawal(user.getId());
+  }
+
+  @GetMapping("/getInfo")
+  public ResponseEntity<UserDto> getInfo(@AuthenticationPrincipal User user) {
+    return ResponseEntity.ok(userService.getInfo(user.getId()));
+  }
+
+  @GetMapping("/ckEmailOverLap")
+  public ResponseEntity<Boolean> ckEmailOverLap(@RequestParam String email) {
+    return ResponseEntity.ok(userService.ckEmailOverLap(email));
+  }
+}

--- a/game-api/src/main/java/com/tang/game/user/dto/SigninForm.java
+++ b/game-api/src/main/java/com/tang/game/user/dto/SigninForm.java
@@ -1,0 +1,22 @@
+package com.tang.game.user.dto;
+
+import javax.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SigninForm {
+
+  @Column(nullable = false)
+  private String email;
+
+  @Column(nullable = false)
+  private String password;
+}

--- a/game-api/src/main/java/com/tang/game/user/dto/SignupForm.java
+++ b/game-api/src/main/java/com/tang/game/user/dto/SignupForm.java
@@ -1,0 +1,30 @@
+package com.tang.game.user.dto;
+
+import com.tang.core.type.Gender;
+import javax.persistence.Column;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class SignupForm {
+  @Column(nullable = false)
+  private String email;
+
+  @Column(nullable = false)
+  private String nickname;
+
+  @Column(nullable = false)
+  private String password;
+
+  @Enumerated(EnumType.STRING)
+  private Gender gender;
+
+  private String ageRange;
+}

--- a/game-api/src/main/java/com/tang/game/user/dto/SignupForm.java
+++ b/game-api/src/main/java/com/tang/game/user/dto/SignupForm.java
@@ -7,10 +7,12 @@ import javax.persistence.Enumerated;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class SignupForm {

--- a/game-api/src/main/java/com/tang/game/user/dto/UserDto.java
+++ b/game-api/src/main/java/com/tang/game/user/dto/UserDto.java
@@ -1,0 +1,30 @@
+package com.tang.game.user.dto;
+
+import com.tang.core.type.Gender;
+import com.tang.core.type.SignupPath;
+import com.tang.game.user.domain.User;
+import com.tang.game.user.type.UserStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class UserDto {
+  private String email;
+  private String nickname;
+  private Gender gender;
+  private UserStatus status;
+  private SignupPath signupPath;
+
+  public static UserDto from(User user) {
+    return UserDto.builder()
+        .email(user.getEmail())
+        .nickname(user.getNickname())
+        .gender(user.getGender())
+        .status(user.getStatus())
+        .signupPath(user.getSignupPath())
+        .build();
+  }
+}

--- a/game-api/src/main/java/com/tang/game/user/dto/WithdrawalForm.java
+++ b/game-api/src/main/java/com/tang/game/user/dto/WithdrawalForm.java
@@ -1,0 +1,16 @@
+package com.tang.game.user.dto;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WithdrawalForm {
+  @NotBlank
+  private String password;
+}

--- a/game-api/src/main/java/com/tang/game/user/repository/UserRepository.java
+++ b/game-api/src/main/java/com/tang/game/user/repository/UserRepository.java
@@ -9,7 +9,10 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-  Optional<User> findByEmailAndSignupPath(String email, SignupPath signupPath);
+
+  Optional<User> findByEmailAndSignupPathAndStatus(String email, SignupPath signupPath, UserStatus status);
 
   Optional<User> findByIdAndStatus(Long userId, UserStatus status);
+
+  boolean existsByEmailAndStatus(String email, UserStatus status);
 }

--- a/game-api/src/main/java/com/tang/game/user/repository/UserRepository.java
+++ b/game-api/src/main/java/com/tang/game/user/repository/UserRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-  Optional<User> findByEmailAndSignupPath(String email, SignupPath SignupPath);
+  Optional<User> findByEmailAndSignupPath(String email, SignupPath signupPath);
 
   Optional<User> findByIdAndStatus(Long userId, UserStatus status);
 }

--- a/game-api/src/main/java/com/tang/game/user/repository/UserRepository.java
+++ b/game-api/src/main/java/com/tang/game/user/repository/UserRepository.java
@@ -3,6 +3,7 @@ package com.tang.game.user.repository;
 import com.tang.core.type.SignupPath;
 import com.tang.game.user.domain.User;
 import com.tang.game.user.type.UserStatus;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -15,4 +16,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByIdAndStatus(Long userId, UserStatus status);
 
   boolean existsByEmailAndStatus(String email, UserStatus status);
+
+  boolean existsByEmailAndDeletedAtNullOrDeletedAtBefore(String email, LocalDateTime localDateTime);
 }

--- a/game-api/src/main/java/com/tang/game/user/service/CustomUserDetailService.java
+++ b/game-api/src/main/java/com/tang/game/user/service/CustomUserDetailService.java
@@ -1,0 +1,23 @@
+package com.tang.game.user.service;
+
+import com.tang.game.common.exception.JamGameException;
+import com.tang.game.common.type.ErrorCode;
+import com.tang.game.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    return userRepository.findById(Long.valueOf(username))
+        .orElseThrow(() -> new JamGameException(ErrorCode.USER_NOT_FOUND));
+  }
+}

--- a/game-api/src/main/java/com/tang/game/user/service/UserService.java
+++ b/game-api/src/main/java/com/tang/game/user/service/UserService.java
@@ -14,6 +14,7 @@ import com.tang.game.user.dto.SigninForm;
 import com.tang.game.user.dto.SignupForm;
 import com.tang.game.user.dto.UserDto;
 import com.tang.game.user.repository.UserRepository;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -33,6 +34,11 @@ public class UserService {
   private final PasswordEncoder bCryptPasswordEncoder;
 
   public void signup(SignupForm form) {
+    if (userRepository.existsByEmailAndDeletedAtNullOrDeletedAtBefore(
+        form.getEmail(), LocalDateTime.now().minusDays(7))) {
+      throw new JamGameException(ErrorCode.ALREADY_EXIST_EMAIL);
+    }
+
     userRepository.save(User.of(form, bCryptPasswordEncoder));
   }
 

--- a/game-api/src/main/java/com/tang/game/user/service/UserService.java
+++ b/game-api/src/main/java/com/tang/game/user/service/UserService.java
@@ -1,0 +1,72 @@
+package com.tang.game.user.service;
+
+import static com.tang.core.type.SignupPath.JAM;
+import static com.tang.game.user.type.UserStatus.VALID;
+
+import com.tang.game.common.exception.JamGameException;
+import com.tang.game.common.type.ErrorCode;
+import com.tang.game.token.Service.TokenProvider;
+import com.tang.game.token.domain.Token;
+import com.tang.game.token.dto.JwtTokenDto;
+import com.tang.game.token.repository.TokenRepository;
+import com.tang.game.user.domain.User;
+import com.tang.game.user.dto.SigninForm;
+import com.tang.game.user.dto.SignupForm;
+import com.tang.game.user.dto.UserDto;
+import com.tang.game.user.repository.UserRepository;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+  private final TokenProvider tokenProvider;
+
+  private final UserRepository userRepository;
+
+  private final TokenRepository tokenRepository;
+
+  private final PasswordEncoder bCryptPasswordEncoder;
+
+  public void signup(SignupForm form) {
+    userRepository.save(User.of(form, bCryptPasswordEncoder));
+  }
+
+  @Transactional
+  public JwtTokenDto login(SigninForm form) {
+    User user = userRepository.findByEmailAndSignupPathAndStatus(form.getEmail(), JAM, VALID)
+        .filter(it -> bCryptPasswordEncoder.matches(form.getPassword(), it.getPassword()))
+        .orElseThrow(() -> new JamGameException(ErrorCode.EMAIL_OR_PASSWORD_UN_MATCH));
+
+    JwtTokenDto jwtTokenDto = tokenProvider.generateToken(
+        user.getId(),
+        Collections.singletonList(user.getStatus().getKey())
+    );
+
+    tokenRepository.save(Token.of(user.getId(), jwtTokenDto));
+
+    return jwtTokenDto;
+  }
+
+  public boolean ckEmailOverLap(String email) {
+    return userRepository.existsByEmailAndStatus(email, VALID);
+  }
+
+  @Transactional
+  public void withdrawal(Long userId) {
+    userRepository.delete(findByUserId(userId));
+  }
+
+  public UserDto getInfo(Long userId) {
+    return UserDto.from(findByUserId(userId));
+  }
+
+  private User findByUserId(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new JamGameException(ErrorCode.USER_NOT_FOUND));
+  }
+}

--- a/game-api/src/test/java/com/tang/game/WithMockCustomUser.java
+++ b/game-api/src/test/java/com/tang/game/WithMockCustomUser.java
@@ -1,0 +1,13 @@
+package com.tang.game;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+  String userName() default "1";
+  String role() default "VALID";
+
+}

--- a/game-api/src/test/java/com/tang/game/WithMockCustomUserSecurityContextFactory.java
+++ b/game-api/src/test/java/com/tang/game/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,22 @@
+package com.tang.game;
+
+import java.util.List;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithMockCustomUserSecurityContextFactory implements
+    WithSecurityContextFactory<WithMockCustomUser> {
+  @Override
+  public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
+    final SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+
+    final UsernamePasswordAuthenticationToken authenticationToken
+        = new UsernamePasswordAuthenticationToken(annotation.userName(), null,
+        List.of(new SimpleGrantedAuthority(annotation.role())));
+    securityContext.setAuthentication(authenticationToken);
+    return securityContext;
+  }
+}

--- a/game-api/src/test/java/com/tang/game/user/controller/UserControllerTest.java
+++ b/game-api/src/test/java/com/tang/game/user/controller/UserControllerTest.java
@@ -1,0 +1,214 @@
+package com.tang.game.user.controller;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tang.core.type.Gender;
+import com.tang.core.type.SignupPath;
+import com.tang.game.WithMockCustomUser;
+import com.tang.game.token.Service.TokenProvider;
+import com.tang.game.token.dto.JwtTokenDto;
+import com.tang.game.user.domain.User;
+import com.tang.game.user.dto.SigninForm;
+import com.tang.game.user.dto.SignupForm;
+import com.tang.game.user.dto.UserDto;
+import com.tang.game.user.repository.UserRepository;
+import com.tang.game.user.service.UserService;
+import com.tang.game.user.type.UserStatus;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(UserController.class)
+@AutoConfigureRestDocs
+@ExtendWith({RestDocumentationExtension.class})
+public class UserControllerTest {
+
+  @MockBean
+  private UserService userService;
+
+  @MockBean
+  private TokenProvider tokenProvider;
+
+  @MockBean
+  private UserRepository userRepository;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  private String token = "임의의 token";
+
+  @Test
+  @WithMockUser
+  @DisplayName("회원가입 성공")
+  void successSignUp() throws Exception {
+    //given
+    //when
+    //then
+    String body = objectMapper.writeValueAsString(getSignupForm());
+
+    mockMvc.perform(post("/users/signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(csrf())
+            .content(body)
+        )
+        .andDo(print())
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser
+  @DisplayName("로그인 성공")
+  void successLogin() throws Exception {
+    //given
+    LocalDateTime localDateTime = LocalDateTime.now();
+
+    given(userService.login(any(SigninForm.class)))
+        .willReturn(getJwtTokenDto(localDateTime));
+    //when
+    //then
+    String body = objectMapper.writeValueAsString(getSigninForm());
+
+    String ACCESS_TOKEN_EXPIRES_TIME = Date.from(localDateTime
+        .plusDays(1)
+        .atZone(ZoneId.systemDefault())
+        .toInstant()).toString();
+
+    String REFRESH_TOKEN_EXPIRES_TIME = Date.from(localDateTime
+        .plusDays(30)
+        .atZone(ZoneId.systemDefault())
+        .toInstant()).toString();
+
+    mockMvc.perform(post("/users/login")
+            .content(body)
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(csrf())
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(header().string("ACCESS_TOKEN", "accessToken"))
+        .andExpect(header().string("REFRESH_TOKEN", "refreshToken"))
+        .andExpect(header().string("ACCESS_TOKEN_EXPIRES_TIME", ACCESS_TOKEN_EXPIRES_TIME))
+        .andExpect(header().string("REFRESH_TOKEN_EXPIRES_TIME", REFRESH_TOKEN_EXPIRES_TIME));
+  }
+
+  @Test
+  @WithMockCustomUser
+  @DisplayName("성공 회원 탈퇴")
+  void successWithdrawal() throws Exception {
+    //then
+    mockMvc.perform(
+        post("/users/withdrawal")
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(csrf())
+        )
+        .andDo(print())
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser
+  @DisplayName("성공 회원 정보 불러오기")
+  void successGetInfo() throws Exception {
+    //given
+    UserDto userDto = getUserDto();
+
+    given(userService.getInfo(anyLong())).willReturn(userDto);
+
+    //when
+    //then
+    mockMvc.perform(get("/users/getInfo")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .with(csrf())
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("email").value(userDto.getEmail()))
+        .andExpect(jsonPath("nickname").value(userDto.getNickname()))
+        .andExpect(jsonPath("gender").value(userDto.getGender().toString()))
+        .andExpect(jsonPath("status").value(userDto.getStatus().toString()))
+        .andExpect(jsonPath("signupPath").value(userDto.getSignupPath().toString()));
+  }
+
+  private SignupForm getSignupForm() {
+    return SignupForm.builder()
+        .email("xoals25@naver.com")
+        .nickname("nickname")
+        .password("123")
+        .gender(Gender.MALE)
+        .ageRange("30~39")
+        .build();
+  }
+
+  private SigninForm getSigninForm() {
+    return SigninForm.builder()
+        .email("xoals25@naver.com")
+        .password("123")
+        .build();
+  }
+
+  private JwtTokenDto getJwtTokenDto(LocalDateTime localDateTimeNow) {
+    return JwtTokenDto.builder()
+        .jwtAccessToken("accessToken")
+        .jwtRefreshToken("refreshToken")
+        .jwtAccessTokenExpiresTime(
+            Date.from(
+                localDateTimeNow
+                    .plusDays(1)
+                    .atZone(ZoneId.systemDefault())
+                    .toInstant())
+        )
+        .jwtRefreshTokenExpiresTime(
+            Date.from(
+                localDateTimeNow
+                    .plusDays(30)
+                    .atZone(ZoneId.systemDefault())
+                    .toInstant()))
+        .build();
+  }
+
+  private UserDto getUserDto() {
+    return UserDto.builder()
+        .email("xoals25@naver.com")
+        .gender(Gender.MALE)
+        .signupPath(SignupPath.JAM)
+        .status(UserStatus.VALID)
+        .nickname("엄탱")
+        .build();
+  }
+
+  private User getUser() {
+    return User.builder()
+        .id(1L)
+        .password("123")
+        .email("xoals25@naver.com")
+        .status(UserStatus.VALID)
+        .build();
+  }
+}


### PR DESCRIPTION
## 변경사항
### AS-IS
1. 앱 자체 회원가입 구현
    - oauth으로만 회원가입 및 로그인을 할 수 있게 할려고 했지만 앱 자체에서 회원가입 기능을 구현했습니다.
2. 앱 자체 회원가입 비밀번호 암호화
    - Spring Security에서 제공하는 클래스 BCryptPasswordEncoder를 이용하여 암호화 및 암호 확인을 구현했습니다.
    - 하지만 프론트엔드에서도 암호화된 상태로 보내줘야 된다고 생각하며, 암호화된 상태로 보내주게 되면 암호확인이 제대로 될 수 있는지 테스트 해봐야 합니다.
3. JWT의 token 생성 부분 수정
    - token을 생성할 때 사용한 email과 가입경로를 제거 후에 db의 user 고유 번호만을 사용하는 것으로 변경했습니다.

### TO-BE
1. 게임 관련 기능
    - 게임 준비 및 게임 시작
    - 게임 진행
        - 제시어 출제
        - 제시어에 맞게 답 작성
             - 작성한 답 체크 기능 (db에 없으면 사전 api를 사용하여 검증)
        - 우승자 선정
        - 우승자 점수 주기

## 테스트
- [ ] 테스트 코드
- [x] API 테스트

테스트 코드에서 질문이 있습니다.
controller에서 @AuthenticationPrincipal를 사용하여 User를 가져오고 있습니다.
근데 테스트 코드에서 @AuthenticationPrincipal를 사용하여 가져오는 User가 null값으로 들어와서 어려움을 겪고 있는 상황입니다. 
아래는 제가 시도한 방법들입니다.
1. @WithMockUser
2. @WithMockCustomUser annotation을 직접 만들어서 사용
3. @WithAnonymousUser
4. 직접 SecurityContext에 Authentication를 직접 주입

제가 시도한 방법들이 되어야 하는데 제가 잘 못 사용하는건지.. 아니면 다른 방법이 있는지 궁금합니다. 